### PR TITLE
fix: use dynamic image tags for both frontend and backend in deployment

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -149,6 +149,7 @@ jobs:
           helm upgrade --install ${{ env.RELEASE }} ./helm-chart \
             $VALUES_FLAG \
             --set backend.image.tag="${{ steps.tag.outputs.value }}" \
+            --set frontend.image.tag="${{ steps.tag.outputs.value }}" \
             --namespace=dashboard \
             --wait --timeout=20m \
             --debug
@@ -276,6 +277,7 @@ jobs:
           helm upgrade --install ${{ env.RELEASE }} ./helm-chart \
             $VALUES_FLAG \
             --set frontend.image.tag="${{ steps.tag.outputs.value }}" \
+            --set backend.image.tag="${{ steps.tag.outputs.value }}" \
             --namespace=dashboard \
             --wait --timeout=20m \
             --debug


### PR DESCRIPTION
- Frontend and backend now use the same dynamically generated tag (e.g., sit-abcd1234)
- Both jobs set both image tags to ensure consistency
- Resolves issue where frontend was stuck on hardcoded 2.2.0 tag

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

## Summary

**Issue:** Enter the issue(s) this pull request resolves.

A clear and concise description of this pull request

## Type (Fill in "x" to check)

- [x] Bug Fix
- [ ] New Feature

## Checklist

Please make sure that all items are checked before submitting this request.

- [ ] Code linter has been run and issues have all been resolved
- [ ] The code has been thoroughly tested and no visible bugs have been introduced
- [ ] The pull request will completely resolve the issue(s) mentioned
- [ ] The pull request only resolves the issue(s) mentioned and nothing more

## Additional context

Add any other context here.
