### PR TITLE
fix: ensure nginx runs in foreground

### DIFF
--- a/Taipei-City-Dashboard-FE/docker-entrypoint.sh
+++ b/Taipei-City-Dashboard-FE/docker-entrypoint.sh
@@ -15,7 +15,6 @@ envsubst '${BACKEND_URL}' < /etc/nginx/conf.d/nginx.conf.template > /tmp/nginx/d
 
 # Create main nginx config file
 cat > /tmp/nginx.conf << 'NGINXCONF'
-user nginx;
 worker_processes auto;
 error_log /var/log/nginx/error.log warn;
 pid /var/run/nginx.pid;
@@ -41,4 +40,4 @@ http {
 NGINXCONF
 
 # Start nginx with custom config
-exec nginx -c /tmp/nginx.conf
+exec nginx -c /tmp/nginx.conf -g 'daemon off;'


### PR DESCRIPTION
- Remove user directive warning
- Add 'daemon off;' to keep nginx running in foreground
- Prevent container from exiting immediately

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

## Summary

**Issue:** Enter the issue(s) this pull request resolves.

A clear and concise description of this pull request

## Type (Fill in "x" to check)

- [ ] Bug Fix
- [ ] New Feature

## Checklist

Please make sure that all items are checked before submitting this request.

- [ ] Code linter has been run and issues have all been resolved
- [ ] The code has been thoroughly tested and no visible bugs have been introduced
- [ ] The pull request will completely resolve the issue(s) mentioned
- [ ] The pull request only resolves the issue(s) mentioned and nothing more

## Additional context

Add any other context here.
