### PR TITLE
feat: configure Gmail SMTP for Airflow email notifications

### DIFF
--- a/Taipei-City-Dashboard-DE/docker/prod/docker-compose.yaml
+++ b/Taipei-City-Dashboard-DE/docker/prod/docker-compose.yaml
@@ -71,6 +71,14 @@ x-airflow-common:
     # WARNING: Use _PIP_ADDITIONAL_REQUIREMENTS option ONLY for a quick checks
     # for other purpose (development, test and especially production usage) build/extend Airflow image.
     _PIP_ADDITIONAL_REQUIREMENTS: ${_PIP_ADDITIONAL_REQUIREMENTS:-}
+    # Gmail SMTP Configuration
+    AIRFLOW__SMTP__SMTP_HOST: 'smtp.gmail.com'
+    AIRFLOW__SMTP__SMTP_STARTTLS: 'True'
+    AIRFLOW__SMTP__SMTP_SSL: 'False'
+    AIRFLOW__SMTP__SMTP_PORT: 587
+    AIRFLOW__SMTP__SMTP_USER: ${SMTP_USER}
+    AIRFLOW__SMTP__SMTP_PASSWORD: ${SMTP_PASSWORD}
+    AIRFLOW__SMTP__SMTP_MAIL_FROM: ${SMTP_MAIL_FROM}
     # The following line can be used to set a custom config file, stored in the local config folder
     # If you want to use it, outcomment it and replace airflow.cfg with the name of your config file
     # AIRFLOW_CONFIG: '/opt/airflow/config/airflow.cfg'


### PR DESCRIPTION
- Add Gmail SMTP settings in docker-compose.yaml
- Configure airflow.cfg with Gmail SMTP credentials
- Support email notifications on task failure/retry
- SMTP settings: smtp.gmail.com:587 with STARTTLS

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

## Summary

**Issue:** Enter the issue(s) this pull request resolves.

A clear and concise description of this pull request

## Type (Fill in "x" to check)

- [ ] Bug Fix
- [ ] New Feature

## Checklist

Please make sure that all items are checked before submitting this request.

- [ ] Code linter has been run and issues have all been resolved
- [ ] The code has been thoroughly tested and no visible bugs have been introduced
- [ ] The pull request will completely resolve the issue(s) mentioned
- [ ] The pull request only resolves the issue(s) mentioned and nothing more

## Additional context

Add any other context here.
