### PR TITLE
fix(ci): 解決 Runner 空間不足問題

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -110,6 +110,16 @@ jobs:
       group: deploy-${{ github.ref }}
       cancel-in-progress: false
     steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
       - name: Checkout
         uses: actions/checkout@v4
 


### PR DESCRIPTION
在 `build-and-deploy` Job 中，由於 Docker 映像檔建置資源需求高，導致 GitHub Hosted Runner 經常因硬碟空間耗盡而失敗 ("No space left on device")。

- 在 `build-and-deploy` Job 的 Steps 最前方新增 `jlumbroso/free-disk-space` Action。
- 此步驟用於清除 Runner 中預裝的大型 SDKs (如 Android/dotnet)，以騰出約 10GB 以上的可用磁碟空間，確保 BE 和 FE 的 Docker Build 能夠順利完成。

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

## Summary

**Issue:** Enter the issue(s) this pull request resolves.

A clear and concise description of this pull request

## Type (Fill in "x" to check)

- [x] Bug Fix
- [ ] New Feature

## Checklist

Please make sure that all items are checked before submitting this request.

- [ ] Code linter has been run and issues have all been resolved
- [ ] The code has been thoroughly tested and no visible bugs have been introduced
- [ ] The pull request will completely resolve the issue(s) mentioned
- [ ] The pull request only resolves the issue(s) mentioned and nothing more

## Additional context

Add any other context here.
