### PR TITLE
[Team no10] allinone — DAG 整併 (1 支)

### DIFF
--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/food_hygiene_grading/food_hygiene_grading.py
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/food_hygiene_grading/food_hygiene_grading.py
@@ -1,0 +1,79 @@
+from airflow import DAG
+from operators.common_pipeline import CommonDag
+
+
+def _ensure_ready_table(engine, table_name, col_map):
+    from sqlalchemy.sql import text as sa_text
+    from utils.generate_sql_to_create_DB_table import generate_sql_to_create_db_table
+
+    sql = generate_sql_to_create_db_table(table_name, col_map)
+    with engine.connect() as conn:
+        conn.execute(sa_text(sql).execution_options(autocommit=True))
+
+
+def _food_hygiene_grading(**kwargs):
+    import pandas as pd
+    from sqlalchemy import create_engine
+    from utils.extract_stage import (
+        get_current_rid_from_page_id,
+        get_data_taipei_api,
+    )
+    from utils.load_stage import (
+        save_dataframe_to_postgresql,
+        update_lasttime_in_data_to_dataset_info,
+    )
+    from utils.transform_time import convert_str_to_time_format
+
+    ready_data_db_uri = kwargs.get("ready_data_db_uri")
+    dag_infos = kwargs.get("dag_infos")
+    dag_id = dag_infos.get("dag_id")
+    load_behavior = dag_infos.get("load_behavior")
+    default_table = dag_infos.get("ready_data_default_table")
+    history_table = dag_infos.get("ready_data_history_table")
+
+    PAGE_ID = "59579c19-a561-4564-8c0f-545bfb32c0f6"
+
+    COL_MAP = {
+        "data_time": 'timestamp with time zone DEFAULT CURRENT_TIMESTAMP',
+        "district_code": 'character varying(10) COLLATE pg_catalog."default"',
+        "business_name": 'text COLLATE pg_catalog."default"',
+        "registration_id": 'character varying(30) COLLATE pg_catalog."default"',
+        "address": 'text COLLATE pg_catalog."default"',
+        "grading_result": 'character varying(10) COLLATE pg_catalog."default"',
+    }
+    SELECT_COLUMNS = list(COL_MAP.keys())
+
+    # Extract
+    rid = get_current_rid_from_page_id(PAGE_ID)
+    raw_data = get_data_taipei_api(rid, output_format="dataframe")
+
+    # Transform
+    data = raw_data.rename(
+        columns={
+            "行政區域代碼": "district_code",
+            "業者名稱店名": "business_name",
+            "食品業者登錄字號": "registration_id",
+            "地址": "address",
+            "評核結果": "grading_result",
+        }
+    )
+    data["data_time"] = convert_str_to_time_format(data["data_time"])
+    data = data[SELECT_COLUMNS]
+
+    # Load
+    engine = create_engine(ready_data_db_uri)
+    _ensure_ready_table(engine, default_table, COL_MAP)
+    save_dataframe_to_postgresql(
+        engine,
+        data=data,
+        load_behavior=load_behavior,
+        default_table=default_table,
+        history_table=history_table,
+    )
+    update_lasttime_in_data_to_dataset_info(
+        engine, dag_id, data["data_time"].max()
+    )
+
+
+dag = CommonDag(proj_folder="proj_city_dashboard", dag_folder="food_hygiene_grading")
+dag.create_dag(etl_func=_food_hygiene_grading)

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/food_hygiene_grading/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/food_hygiene_grading/job_config.json
@@ -1,0 +1,38 @@
+{
+  "dag_infos": {
+    "dag_id": "food_hygiene_grading",
+    "start_date": "2026-05-06",
+    "schedule_interval": "@daily",
+    "catchup": false,
+    "tags": ["food_hygiene", "衛生局", "Taipei-City"],
+    "description": "臺北市通過餐飲衛生管理分級評核業者(衛生局,data.taipei)",
+    "default_args": {
+      "owner": "airflow",
+      "email": ["DEFAULT_EMAIL_LIST"],
+      "email_on_retry": false,
+      "email_on_failure": true,
+      "retries": 1,
+      "retry_delay": 60
+    },
+    "ready_data_db": "postgres_default",
+    "ready_data_default_table": "food_hygiene_grading",
+    "ready_data_history_table": "",
+    "raw_data_db": "postgres_default",
+    "raw_data_table": "",
+    "load_behavior": "replace"
+  },
+  "data_infos": {
+    "component_name": "food_hygiene_grading",
+    "name_cn": "臺北市通過餐飲衛生管理分級評核業者",
+    "airflow_update_freq": "每日(資料源實際每年更新一次)",
+    "source": "https://data.taipei/dataset/detail?id=59579c19-a561-4564-8c0f-545bfb32c0f6",
+    "source_type": "data.taipei",
+    "source_dept": "臺北市政府衛生局",
+    "gis_format": null,
+    "output_coordinate": "EPSG:4326",
+    "is_geometry": 0,
+    "dataset_description": "臺北市通過餐飲衛生管理分級評核之業者清單,含行政區、業者名稱、食品業者登錄字號、地址與評核結果(優/良/普通)",
+    "etl_description": "由 data.taipei page_id 動態解析最新 rid → get_data_taipei_api 取全量 → rename 中文欄位 → data_time 標準化 → replace 寫入 ready DB",
+    "sensitivity": "public"
+  }
+}

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/food_hygiene_grading/test_food_hygiene_grading.py
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/food_hygiene_grading/test_food_hygiene_grading.py
@@ -1,0 +1,142 @@
+"""Test for food_hygiene_grading DAG.
+
+驗證 data_infos.source 可達且回傳合理資料。**不**需要 Airflow / Postgres。
+
+Run from DAG folder:
+    python test_food_hygiene_grading.py
+或從 toolkit:
+    python Taipei-City-Dashboard-DE/dag-toolkit/scripts/scan_all_tests.py
+"""
+from __future__ import annotations
+
+import json
+import sys
+from io import StringIO
+from pathlib import Path
+from typing import Any
+
+import requests
+
+
+HERE = Path(__file__).parent
+CONFIG = json.loads((HERE / "job_config.json").read_text(encoding="utf-8"))
+DATA_INFOS = CONFIG["data_infos"]
+DAG_INFOS = CONFIG["dag_infos"]
+SOURCE_URL = DATA_INFOS["source"]
+SOURCE_TYPE = DATA_INFOS["source_type"]
+TABLE_NAME = DAG_INFOS["dag_id"]
+
+# === 視 source_type 填 ===
+# data.taipei: 把 dataset detail 頁面對應的 resource id 填進來(必填)
+RID = "c5646d80-9118-4439-b924-075f96371d75"
+# csv / csv-big5 編碼:utf-8 / big5 / cp950
+ENCODING = "utf-8"
+
+
+def _fetch_data_taipei(rid: str) -> list[dict]:
+    if not rid:
+        raise AssertionError(
+            "source_type=data.taipei 但 RID 未填,請於 test 頂端 RID 變數填入 dataset 的 resource id"
+        )
+    url = f"https://data.taipei/api/v1/dataset/{rid}?scope=resourceAquire&limit=2"
+    res = requests.get(url, timeout=30)
+    res.raise_for_status()
+    body = res.json()
+    records = (body.get("result") or {}).get("results") \
+              or (body.get("result") or {}).get("records") \
+              or (body.get("payload") or {}).get("records")
+    if not records:
+        raise AssertionError(f"data.taipei 沒回傳記錄;body keys: {list(body)}")
+    return records
+
+
+def _fetch_csv(url: str, encoding: str):
+    import pandas as pd
+    res = requests.get(url, timeout=60)
+    res.raise_for_status()
+    text = res.content.decode(encoding, errors="replace")
+    df = pd.read_csv(StringIO(text))
+    if df.empty:
+        raise AssertionError("CSV is empty")
+    if len(df.columns) == 0:
+        raise AssertionError("CSV has no columns")
+    return df
+
+
+def _fetch_binary(url: str) -> int:
+    """SHP / ZIP / KML 等二進位:HEAD 看 size,失敗就 streaming GET 一段。"""
+    head = requests.head(url, timeout=30, allow_redirects=True)
+    head.raise_for_status()
+    size = int(head.headers.get("Content-Length", "0"))
+    if size > 0:
+        return size
+    # fallback
+    res = requests.get(url, timeout=60, stream=True)
+    res.raise_for_status()
+    chunk = next(res.iter_content(chunk_size=4096), b"")
+    if not chunk:
+        raise AssertionError("Source 回應為空")
+    return -1   # unknown size 但有資料
+
+
+def _fetch_json(url: str) -> Any:
+    res = requests.get(url, timeout=30)
+    res.raise_for_status()
+    body = res.json()
+    if not body:
+        raise AssertionError("JSON response is empty")
+    return body
+
+
+def _fetch_data_ntpc(url: str) -> list[dict]:
+    body = _fetch_json(url)
+    records = body.get("result", {}).get("records") if isinstance(body, dict) else None
+    if not records:
+        raise AssertionError(f"data.ntpc 沒回傳記錄;body: {str(body)[:200]}")
+    return records
+
+
+def test_source_url_reachable():
+    """資料源 URL 可達且回傳合理資料(必過)。"""
+    print(f"[{TABLE_NAME}] source_type={SOURCE_TYPE}")
+
+    if SOURCE_TYPE == "data.taipei":
+        records = _fetch_data_taipei(RID)
+        print(f"  ✅ data.taipei reachable, {len(records)} sample records")
+        print(f"     keys: {list(records[0].keys())[:10]}")
+
+    elif SOURCE_TYPE in ("csv", "csv-big5"):
+        enc = "big5" if SOURCE_TYPE == "csv-big5" else ENCODING
+        df = _fetch_csv(SOURCE_URL, encoding=enc)
+        print(f"  ✅ CSV reachable, {len(df)} rows × {len(df.columns)} cols")
+        print(f"     columns: {list(df.columns)[:10]}")
+
+    elif SOURCE_TYPE in ("shp", "geojson", "kml", "zip"):
+        size = _fetch_binary(SOURCE_URL)
+        print(f"  ✅ {SOURCE_TYPE.upper()} reachable, Content-Length: {'unknown' if size < 0 else f'{size:,} bytes'}")
+
+    elif SOURCE_TYPE in ("api", "json"):
+        body = _fetch_json(SOURCE_URL)
+        keys = list(body)[:10] if isinstance(body, dict) else f"list[{len(body)}]"
+        print(f"  ✅ JSON API reachable, top-level: {keys}")
+
+    elif SOURCE_TYPE == "data.ntpc":
+        records = _fetch_data_ntpc(SOURCE_URL)
+        print(f"  ✅ data.ntpc reachable, {len(records)} sample records")
+
+    else:
+        # fallback:單純 GET 確認 200 + 非空
+        res = requests.get(SOURCE_URL, timeout=30)
+        res.raise_for_status()
+        if not res.content:
+            raise AssertionError(f"source_type={SOURCE_TYPE} 回應為空")
+        print(f"  ✅ {SOURCE_TYPE} reachable (fallback), bytes: {len(res.content):,}")
+
+
+if __name__ == "__main__":
+    try:
+        test_source_url_reachable()
+    except Exception as e:
+        print(f"❌ FAIL [{TABLE_NAME}]: {e}", file=sys.stderr)
+        sys.exit(1)
+    print("All tests passed")


### PR DESCRIPTION
> **PR target**: `feature/award-dag-integration`(2026 雙北儀表板 DAG 整併)
> **PR source**: `feature/demo-team-no10-allinone`

## 本 PR 包含 DAG 清單

| # | proj_folder | table_name | name_cn | component_name | load_behavior | is_geometry |
| --- | --- | --- | --- | --- | --- | --- |
| 1 | proj_city_dashboard | food_hygiene_grading | 臺北市通過餐飲衛生管理分級評核業者 | food_hygiene_grading | replace | 0 |

---

## DAG 1 — `proj_city_dashboard/food_hygiene_grading` — `臺北市通過餐飲衛生管理分級評核業者`

### 資料來源

- **name_cn**: 臺北市通過餐飲衛生管理分級評核業者
- **source**: https://data.taipei/dataset/detail?id=59579c19-a561-4564-8c0f-545bfb32c0f6
- **source_dept**: 臺北市政府衛生局
- **source_type**: data.taipei
- **component_name**: food_hygiene_grading
- **schedule_interval**: `@daily` (queue: default)
- **load_behavior**: replace
- **是否含 geometry**: no

### DB Schema(由 ETL 函式內 `_ensure_ready_table` 自動建表)

```python
COL_MAP = {
    "data_time":       "timestamp with time zone DEFAULT CURRENT_TIMESTAMP",
    "district_code":   'character varying(10) COLLATE pg_catalog."default"',
    "business_name":   'text COLLATE pg_catalog."default"',
    "registration_id": 'character varying(30) COLLATE pg_catalog."default"',
    "address":         'text COLLATE pg_catalog."default"',
    "grading_result":  'character varying(10) COLLATE pg_catalog."default"',
}
```

### 本機驗證

#### 階段 A — validator

```
$ python3 Taipei-City-Dashboard-DE/dag-toolkit/scripts/validate_dag.py \
    Taipei-City-Dashboard-DE/dags/proj_city_dashboard/food_hygiene_grading

驗證 DAG: proj_city_dashboard/food_hygiene_grading
  [PASS] 三名一致: dag_folder == dag_id == table_name == 'food_hygiene_grading'
  [PASS] 必填鍵齊全(10 項)
  [PASS] tags 完整(3 項,含 city tag)
  [PASS] 頂層 import 純淨(只有 airflow.DAG + CommonDag)
  [PASS] COL_MAP 解析成功(6 欄)
  [PASS] 非 geometry 全鏈路一致
  [PASS] test_food_hygiene_grading.py 含對 source URL 的請求
  ... (24 項全 pass)

Result: PASS (0 warn, 24 pass)
```

#### 階段 B — source URL test

```
$ curl -s -o /dev/null -w "%{http_code}\n" \
    "https://data.taipei/api/v1/dataset/c5646d80-9118-4439-b924-075f96371d75?scope=resourceAquire&limit=2"
200
```

> ⚠️ `python3 test_food_hygiene_grading.py` 在本機 macOS 上回 `SSLCertVerificationError: Missing Subject Key Identifier`,屬本機 Python 憑證問題(非 code bug),改用 curl 直驗 endpoint。test 檔已修正模板 URL bug:`/api/dataset/...` → `/api/v1/dataset/...`(原模板路徑會 404)。

## 待辦

- [ ] 無 Variable / Connection 待建(data.taipei 公開 API)

## Custom inline requests 通知

無 — 走 `utils.extract_stage.get_data_taipei_api`,規則 C 不觸發。

## Reviewer Checklist

- [x] `dag_folder == dag_id == ready_data_default_table` 三名一致
- [x] `data_infos.component_name` 已填且為 snake_case
- [x] `COL_MAP` 完整 vs DataFrame 最終 select 欄位對齊(6 欄)
- [x] 無寫死 email / token / 連線字串
- [x] tags 含主分類、source_dept、city tag(`Taipei-City`)
- [x] 排程合理(@daily → default queue)
- [x] validator PASS
- [ ] 維護者:跑 `python3 Taipei-City-Dashboard-DE/dag-toolkit/scripts/scan_all_tests.py`(於有正常 SSL 憑證的環境)