### PR TITLE
修改: 重新分散 monthly+ DAG 排程至 Taipei 離峰時段

### DIFF
--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D010501/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D010501/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {  
         "dag_id": "D010501",
         "start_date": "2024-06-25",
-        "schedule_interval": "0 19 16 * *",
+        "schedule_interval": "0 17 5,26 * *",
         "catchup": false,
         "tags": ["resh_petition", "研考會", "陳情"],
         "description": "Monthly data of Taipei City Petition System.", 

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D020105/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D020105/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {
         "dag_id": "D020105",
         "start_date": "2024-05-30",
-        "schedule_interval": "0 3 24 6,12 *",
+        "schedule_interval": "0 12 1,22 * *",
         "catchup": false,
         "tags": ["urbn_air_raid_shelter", "都發局", "防空避難處所"],
         "description": "Taipei city's air raid shelter list.",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D020201/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D020201/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {  
         "dag_id": "D020201",
         "start_date": "2024-05-29",
-        "schedule_interval": "20 5 25 * *",
+        "schedule_interval": "30 12 1,22 * *",
         "catchup": false,
         "tags": ["fire_narrow_street", "消防局", "狹小巷道"],
         "description": "Taipei city's narrow street list.", 

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D020301/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D020301/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {  
         "dag_id": "D020301",
         "start_date": "2024-05-29",
-        "schedule_interval": "0 1 7 * *",
+        "schedule_interval": "0 13 1,22 * *",
         "catchup": false,
         "tags": ["tran_cctv", "交通局", "路口監視器"],
         "description": ".", 

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D020401/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D020401/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {  
         "dag_id": "D020401",
         "start_date": "2024-05-29",
-        "schedule_interval": "* * 1 1 *",
+        "schedule_interval": "30 13 1,22 * *",
         "catchup": false,
         "tags": ["eoc_major_case", "消防局", "近兩年重大案件"],
         "description": ".", 

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D030101_1/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D030101_1/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {  
         "dag_id": "D030101-1",
         "start_date": "2022-10-11",
-        "schedule_interval": "0 0 1 * *",
+        "schedule_interval": "0 14 1,22 * *",
         "catchup": false,
         "tags": ["work_sidewalk", "人行道"],
         "description": "Sidewalk in Taipei City(with polygon)", 

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D030102_1/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D030102_1/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {  
         "dag_id": "D030102-1",
         "start_date": "2022-10-11",
-        "schedule_interval": "0 0 1 * *",
+        "schedule_interval": "30 14 1,22 * *",
         "catchup": false,
         "tags": ["tran_urban_bike_path", "市區自行車道"],
         "description": "A More completed DAG for tutorial.", 

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D030102_2/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D030102_2/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {  
         "dag_id": "D030102-2",
         "start_date": "2022-10-11",
-        "schedule_interval": "0 0 1 * *",
+        "schedule_interval": "0 15 1,22 * *",
         "catchup": false,
         "tags": ["work_riverside_bike_path", "河濱自行車道"],
         "description": "A More completed DAG for tutorial.", 

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D030201/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D030201/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {  
         "dag_id": "D030201",
         "start_date": "2024-06-25",
-        "schedule_interval": "0 18 27 6,12 *",
+        "schedule_interval": "30 15 1,22 * *",
         "catchup": false,
         "tags": ["traffic_accident", "交通局", "交通事故"],
         "description": "Detailed information on A1 and A2 types of traffic accidents in Taipei City", 

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D040401/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D040401/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {
         "dag_id": "D040401",
         "start_date": "2024-05-09",
-        "schedule_interval": "0 0 1 * *",
+        "schedule_interval": "0 16 1,22 * *",
         "catchup": false,
         "tags": ["garbage_truck", "環保局", "垃圾車收運點位"],
         "description": "A DAG only contains location and time of garbage trucks from data.Taipei.",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D050201_1/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D050201_1/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {  
         "dag_id": "D050201_1",
         "start_date": "2024-06-11",
-        "schedule_interval": "0 3 9 * *",
+        "schedule_interval": "30 17 5,26 * *",
         "catchup": false,
         "tags": ["work_street_tree", "工務局", "行道樹"],
         "description": "Street tree in Taipei City.", 

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D050301_1/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D050301_1/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {  
         "dag_id": "D050301-1",
         "start_date": "2022-09-25",
-        "schedule_interval": "0 0 1 * *",
+        "schedule_interval": "30 16 1,22 * *",
         "catchup": false,
         "tags": ["work_garden_city", "工務局", "田園城市"],
         "description": "Points of garden cities at Taipei",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D050302_1/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D050302_1/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {  
         "dag_id": "D050302_1",
         "start_date": "2024-06-11",
-        "schedule_interval": "0 2 1 6,12 *",
+        "schedule_interval": "0 18 5,26 * *",
         "catchup": false,
         "tags": ["work_goose_sanctuary", "工務局", "野雁保護區"],
         "description": "Goose sanctuary in Taipei City.", 

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D050302_2/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D050302_2/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {  
         "dag_id": "D050302_2",
         "start_date": "2024-06-11",
-        "schedule_interval": "0 2 2 6,12 *",
+        "schedule_interval": "30 18 5,26 * *",
         "catchup": false,
         "tags": ["work_nature_reserve", "工務局", "自然保留區"],
         "description": "Nature reserve in Taipei City.", 

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D050302_3/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D050302_3/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {  
         "dag_id": "D050302_3",
         "start_date": "2024-06-11",
-        "schedule_interval": "0 2 3 6,12 *",
+        "schedule_interval": "0 19 5,26 * *",
         "catchup": false,
         "tags": ["work_urban_reserve", "工務局", "都市計畫保護區", "都市農業區"],
         "description": "Urban plan reserve land and agricultural land in Taipei City.", 

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D050303_1/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D050303_1/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {  
         "dag_id": "D050303_1",
         "start_date": "2024-06-11",
-        "schedule_interval": "0 2 4 6,12 *",
+        "schedule_interval": "30 19 5,26 * *",
         "catchup": false,
         "tags": ["work_park", "工務局", "公園"],
         "description": "Park in Taipei City.", 

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D050303_2/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D050303_2/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {  
         "dag_id": "D050303_2",
         "start_date": "2024-06-11",
-        "schedule_interval": "0 2 5 6,12 *",
+        "schedule_interval": "0 20 5,26 * *",
         "catchup": false,
         "tags": ["work_school_greening", "工務局", "校園綠化"],
         "description": "school greening in Taipei City.", 

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D050303_3/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D050303_3/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {  
         "dag_id": "D050303_3",
         "start_date": "2024-06-11",
-        "schedule_interval": "0 2 6 6,12 *",
+        "schedule_interval": "30 20 5,26 * *",
         "catchup": false,
         "tags": ["work_eco_park", "工務局", "公園生態化"],
         "description": "Ecology park in Taipei City.", 

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D050303_4/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D050303_4/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {  
         "dag_id": "D050303_4",
         "start_date": "2024-06-11",
-        "schedule_interval": "0 2 7 6,12 *",
+        "schedule_interval": "0 21 5,26 * *",
         "catchup": false,
         "tags": ["work_riverside_park", "工務局", "河濱高灘地"],
         "description": "Riverside park in Taipei City.", 

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D050303_5/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D050303_5/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {
         "dag_id": "D050303_5",
         "start_date": "2024-05-14",
-        "schedule_interval": "0 0 1 * *",
+        "schedule_interval": "0 17 1,22 * *",
         "catchup": false,
         "tags": ["work_permeable_paving_schoool","工務局", "學校透水鋪面"],
         "description": "Information and locations of school permeable pavement from data.taipei.",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D050303_6/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D050303_6/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {
         "dag_id": "D050303_6",
         "start_date": "2024-05-15",
-        "schedule_interval": "0 0 1 * *",
+        "schedule_interval": "30 17 1,22 * *",
         "catchup": false,
         "tags": ["work_permeable_paving_parking","工務局", "停車場透水鋪面"],
         "description": "Information and locations of parking lot permeable pavement from data.taipei.",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D050303_7/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D050303_7/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {
         "dag_id": "D050303_7",
         "start_date": "2024-05-15",
-        "schedule_interval": "0 0 1 * *",
+        "schedule_interval": "0 18 1,22 * *",
         "catchup": false,
         "tags": ["work_permeable_paving_park","工務局", "公園透水鋪面"],
         "description": "Information and locations of parks permeable pavement from data.taipei.",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D050303_8/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D050303_8/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {
         "dag_id": "D050303_8",
         "start_date": "2024-05-15",
-        "schedule_interval": "0 0 1 * *",
+        "schedule_interval": "30 18 1,22 * *",
         "catchup": false,
         "tags": ["work_permeable_paving_sidewalk","工務局", "人行道透水鋪面"],
         "description": "Information and locations of sidewalk permeable pavement from data.taipei.",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D050303_9/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D050303_9/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {
         "dag_id": "D050303_9",
         "start_date": "2024-05-15",
-        "schedule_interval": "0 0 1 * *",
+        "schedule_interval": "0 19 1,22 * *",
         "catchup": false,
         "tags": ["work_permeable_paving_pac","工務局", "PAC透水鋪面"],
         "description": "Information and locations of PAC permeable pavement from data.taipei.",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D050401_1/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D050401_1/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {  
         "dag_id": "D050401_1",
         "start_date": "2024-06-11",
-        "schedule_interval": "0 5 2 5,11 *",
+        "schedule_interval": "30 21 5,26 * *",
         "catchup": false,
         "tags": ["work_soil_liquefaction", "工務局", "土壤液化潛勢"],
         "description": "Soil liquefaction distribution in Taipei City.", 

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D050601/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D050601/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {  
         "dag_id": "D050601",
         "start_date": "2024-05-29",
-        "schedule_interval": "0 1 18 5,11 *",
+        "schedule_interval": "30 19 1,22 * *",
         "catchup": false,
         "tags": ["env_greenhouse_gas_stat", "環保局", "溫室氣體排放統計"],
         "description": ".", 

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D060101_1/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D060101_1/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {  
         "dag_id": "D060101_1",
         "start_date": "2024-06-11",
-        "schedule_interval": "0 5 18 5,11 *",
+        "schedule_interval": "0 12 6,27 * *",
         "catchup": false,
         "tags": ["heal_hospital", "衛生局", "醫院位置"],
         "description": "Hospitals location in Taipei City.", 

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D060101_2/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D060101_2/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {  
         "dag_id": "D060101_2",
         "start_date": "2024-06-11",
-        "schedule_interval": "10 5 18 5,11 *",
+        "schedule_interval": "30 12 6,27 * *",
         "catchup": false,
         "tags": ["heal_clinic", "衛生局", "診所位置"],
         "description": "Clinics location in Taipei City.", 

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D060102_1/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D060102_1/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {  
         "dag_id": "D060102_1",
         "start_date": "2024-06-11",
-        "schedule_interval": "0 7 23 * *",
+        "schedule_interval": "0 13 6,27 * *",
         "catchup": false,
         "tags": ["heal_aed", "衛生局", "AED位置"],
         "description": "AED address and point in Taipei City.", 

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D060103/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D060103/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {  
         "dag_id": "D060103",
         "start_date": "2024-06-25",
-        "schedule_interval": "0 20 26 * *",
+        "schedule_interval": "0 20 1,22 * *",
         "catchup": false,
         "tags": ["socl_welfare_organization", "社會局", "社福機構"],
         "description": "Data with location of social welfare facilities in Taipei City", 

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D060201/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D060201/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {  
         "dag_id": "D060201",
         "start_date": "2024-06-25",
-        "schedule_interval": "0 20 19 * *",
+        "schedule_interval": "30 13 6,27 * *",
         "catchup": false,
         "tags": ["fire_to_hospital", "消防局", "緊急救護統計"],
         "description": "Monthly data of Taipei City Fire Department's emergency medical service statistics.", 

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D070202/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D070202/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {
         "dag_id": "D070202",
         "start_date": "2024-06-03",
-        "schedule_interval": "0 5 27 3,9 *",
+        "schedule_interval": "30 20 1,22 * *",
         "catchup": false,
         "tags": ["stat_power_usage", "主計處", "台電售電量"],
         "description": ".",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D090100_1/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D090100_1/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {  
         "dag_id": "D090100_1",
         "start_date": "2024-06-11",
-        "schedule_interval": "0 5 21 5,11 *",
+        "schedule_interval": "0 14 6,27 * *",
         "catchup": false,
         "tags": ["edu_school", "教育局", "各級學校分布"],
         "description": "Schools address in Taipei City.", 

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D090101_1/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D090101_1/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {  
         "dag_id": "D090101_1",
         "start_date": "2024-06-11",
-        "schedule_interval": "30 6 21 5,11 *",
+        "schedule_interval": "30 14 6,27 * *",
         "catchup": false,
         "tags": ["edu_elementary_school_district", "教育局", "小學學區"],
         "description": "Schools district for elementary schools in Taipei City.", 

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D090101_2/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D090101_2/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {  
         "dag_id": "D090101_2",
         "start_date": "2024-06-05",
-        "schedule_interval": "0 7 21 5,11 *",
+        "schedule_interval": "0 21 1,22 * *",
         "catchup": false,
         "tags": ["edu_eleschool_dist_by_administrative", "教育局", "小學學區里鄰"],
         "description": "School district for elementary schools in Taipei City.", 

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D090103_1/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D090103_1/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {  
         "dag_id": "D090103_1",
         "start_date": "2024-06-11",
-        "schedule_interval": "40 6 21 5,11 *",
+        "schedule_interval": "0 15 6,27 * *",
         "catchup": false,
         "tags": ["edu_junior_high_school_district", "教育局", "中學學區"],
         "description": "Junior high Schools district for elementary schools in Taipei City.", 

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D090103_2/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D090103_2/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {  
         "dag_id": "D090103_2",
         "start_date": "2024-06-05",
-        "schedule_interval": "0 8 21 5,11 *",
+        "schedule_interval": "30 21 1,22 * *",
         "catchup": false,
         "tags": ["edu_jhschool_dist_by_administrative", "教育局", "國中學區里鄰"],
         "description": "School district for junior high schools in Taipei City.", 

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D100101/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D100101/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {
         "dag_id": "D100101",
         "start_date": "2024-04-18",
-        "schedule_interval": "0 0 1 * *",
+        "schedule_interval": "0 12 2,23 * *",
         "catchup": false,
         "tags": ["Nursery_Room", "哺集乳室資訊", "衛生局"],
         "description": "Information and locations of nursery rooms from data.taipei.",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D100102_1/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D100102_1/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {
         "dag_id": "D100102_1",
         "start_date": "2024-05-01",
-        "schedule_interval": "0 0 1 * *",
+        "schedule_interval": "30 12 2,23 * *",
         "catchup": false,
         "tags": ["childcare_family_hub", "臺北市嬰幼兒照顧服務_親子館", "社會局", "臺北市育兒支持資源"],
         "description": "Information and locations of childcare family hubs from data.taipei.",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D100102_2/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D100102_2/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {
         "dag_id": "D100102_2",
         "start_date": "2024-05-01",
-        "schedule_interval": "0 0 1 * *",
+        "schedule_interval": "0 13 2,23 * *",
         "catchup": false,
         "tags": [" childcare_parenting_garden", "臺北市嬰幼兒照顧服務_育兒友善園", "社會局", "臺北市育兒支持資源"],
         "description": "Information and locations of childcare parenting garden from data.taipei.",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D100102_3/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D100102_3/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {
         "dag_id": "D100102_3",
         "start_date": "2024-05-01",
-        "schedule_interval": "0 0 1 * *",
+        "schedule_interval": "30 13 2,23 * *",
         "catchup": false,
         "tags": ["childcare_homecare_hub", "臺北市嬰幼兒照顧服務_居家托育服務中心", 
             "社會局", "臺北市育兒支持資源"],

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D100102_4/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D100102_4/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {
         "dag_id": "D100102_4",
         "start_date": "2024-05-01",
-        "schedule_interval": "0 0 1 * *",
+        "schedule_interval": "0 14 2,23 * *",
         "catchup": false,
         "tags": ["childcare_designated_care_center", "臺北市嬰幼兒照顧服務_定點臨托", 
             "社會局", "臺北市育兒支持資源"],

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D100102_5/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D100102_5/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {
         "dag_id": "D100102_5",
         "start_date": "2024-05-01",
-        "schedule_interval": "0 0 1 * *",
+        "schedule_interval": "30 14 2,23 * *",
         "catchup": false,
         "tags": ["childcare_community_care_hub", "臺北市嬰幼兒照顧服務_社區公共托育家園", 
             "社會局", "臺北市育兒支持資源"],

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D100102_6/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D100102_6/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {
         "dag_id": "D100102_6",
         "start_date": "2024-05-01",
-        "schedule_interval": "0 0 1 * *",
+        "schedule_interval": "0 15 2,23 * *",
         "catchup": false,
         "tags": ["childcare_gov_priv_infant_care", "臺北市嬰幼兒照顧服務_公辦民營托嬰中心", 
             "社會局", "臺北市育兒支持資源"],

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D100102_7/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D100102_7/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {
         "dag_id": "D100102_7",
         "start_date": "2024-05-02",
-        "schedule_interval": "0 0 1 * *",
+        "schedule_interval": "30 15 2,23 * *",
         "catchup": false,
         "tags": ["childcare_private_childcare", "臺北市嬰幼兒照顧服務_私立托嬰中心", 
             "社會局", "臺北市育兒支持資源"],

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D100102_8/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D100102_8/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {
         "dag_id": "D100102_8",
         "start_date": "2024-05-02",
-        "schedule_interval": "0 0 1 * *",
+        "schedule_interval": "0 16 2,23 * *",
         "catchup": false,
         "tags": ["childcare_resource_hub", "臺北市嬰幼兒照顧服務_兒童托育資源中心", 
             "社會局", "臺北市育兒支持資源"],

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D100103/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D100103/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {
         "dag_id": "D100103",
         "start_date": "2024-05-03",
-        "schedule_interval": "0 0 1 3,9 *",
+        "schedule_interval": "30 15 6,27 * *",
         "catchup": false,
         "tags": ["parental_leave", "臺北市就業保險育嬰留職停薪津貼初次核付人數", 
                 "主計處", "育嬰假性別比"],

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D100104_1/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D100104_1/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {
         "dag_id": "D100104_1",
         "start_date": "2024-05-03",
-        "schedule_interval": "0 0 1 3,9 *",
+        "schedule_interval": "30 16 2,23 * *",
         "catchup": false,
         "tags": ["maternity_hospitals", "生育補助合約醫院", "衛生局"],
         "description": "Information and locations of maternity hospitals service from data.taipei.",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D100104_2/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D100104_2/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {
         "dag_id": "D100104_2",
         "start_date": "2024-05-03",
-        "schedule_interval": "0 0 1 3,9 *",
+        "schedule_interval": "0 16 6,27 * *",
         "catchup": false,
         "tags": ["maternity_hospitals_time", "臺北市生育健康篩檢補助及健康服務概況", "主計處"],
         "description": "Information and locations of maternity hospitals service from data.taipei.",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D100105/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D100105/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {
         "dag_id": "D100105",
         "start_date": "2024-05-07",
-        "schedule_interval": "0 0 1 3,9 *",
+        "schedule_interval": "0 17 2,23 * *",
         "catchup": false,
         "tags": ["gynecology_clinic", "臺北市婦產科醫療機構", "衛生局"],
         "description": "Information and locations of Obstetrics and Gynecology Medical Institution from data.taipei.",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D100106_1/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D100106_1/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {
         "dag_id": "D100106_1",
         "start_date": "2024-05-07",
-        "schedule_interval": "0 0 1 * *",
+        "schedule_interval": "30 17 2,23 * *",
         "catchup": false,
         "tags": ["newborn_stats_district", "臺北市各里人口數按年齡分", "民政局"],
         "description": "Information and locations of newborn stats by district from data.taipei.",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D100106_2/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D100106_2/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {
         "dag_id": "D100106_2",
         "start_date": "2024-05-08",
-        "schedule_interval": "0 0 1 * *",
+        "schedule_interval": "0 18 2,23 * *",
         "catchup": false,
         "tags": ["newborn_stats_vil", "臺北市各里人口數按年齡分", "民政局"],
         "description": "Information and locations of newborn stats by village from data.taipei.",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D100106_3/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D100106_3/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {
         "dag_id": "D100106_3",
         "start_date": "2024-05-08",
-        "schedule_interval": "0 0 1 * *",
+        "schedule_interval": "30 16 6,27 * *",
         "catchup": false,
         "tags": ["newborn_stats_time", "臺北市各里人口數按年齡分", "民政局"],
         "description": "Information and locations of newborn stats by village from data.taipei.",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0017/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0017/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {  
         "dag_id": "R0017",
         "start_date": "2021-08-24",
-        "schedule_interval": "30 3 1 4 *",
+        "schedule_interval": "30 18 2,23 * *",
         "catchup": false,
         "tags": ["patrol_designate_place", "教育局", "可供避難收容處所"],
         "description": "List of shelter available for evacuation.", 

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0018/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0018/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {  
         "dag_id": "R0018",
         "start_date": "2021-08-24",
-        "schedule_interval": "@monthly",
+        "schedule_interval": "0 19 2,23 * *",
         "catchup": false,
         "tags": ["patrol_debris", "農業部", "土石流潛勢溪流"],
         "description": "Information of 1732 potential debris flow streams for the year 113 of the Taiwan.", 

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0019/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0019/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {  
         "dag_id": "R0019",
         "start_date": "2021-08-24",
-        "schedule_interval": "@monthly",
+        "schedule_interval": "30 19 2,23 * *",
         "catchup": false,
         "tags": ["patrol_debrisarea", "農業部", "土石流潛勢溪流影響範圍"],
         "description": "Impact areas of 1732 potential debris flow streams for the year 113 of the Taiwan.", 

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0020/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0020/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {
         "dag_id": "R0020",
         "start_date": "2024-06-04",
-        "schedule_interval": "0 3 1 12 *",
+        "schedule_interval": "0 20 2,23 * *",
         "catchup": false,
         "tags": ["patrol_artificial_slope", "工務局", "山坡地人工邊坡"],
         "description": "Locations of artificial slopes in the hillside areas of Taipei City from data.taipei.",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0021/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0021/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {
         "dag_id": "R0021",
         "start_date": "2024-06-04",
-        "schedule_interval": "0 3 2 6,12 *",
+        "schedule_interval": "30 20 2,23 * *",
         "catchup": false,
         "tags": ["patrol_old_settlement", "工務局", "老舊聚落"],
         "description": "Locations of old settlement in Taipei City from data.taipei.",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0023/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0023/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {
         "dag_id": "R0023",
         "start_date": "2021-08-24",
-        "schedule_interval": "0 23 10 * *",
+        "schedule_interval": "0 21 2,23 * *",
         "catchup": false,
         "tags": ["patrol_residential_burglary", "警察局", "住宅竊盜點位資訊"],
         "description": "Residential burglaries in Taipei began in January 2015.",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0024/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0024/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {
         "dag_id": "R0024",
         "start_date": "2021-08-24",
-        "schedule_interval": "30 23 10 * *",
+        "schedule_interval": "30 21 2,23 * *",
         "catchup": false,
         "tags": ["patrol_car_theft", "警察局", "汽車竊盜點位資訊"],
         "description": "Car theft in Taipei began in January 2015.",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0025/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0025/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {
         "dag_id": "R0025",
         "start_date": "2021-08-24",
-        "schedule_interval": "0 0 11 * *",
+        "schedule_interval": "0 12 3,24 * *",
         "catchup": false,
         "tags": ["patrol_motorcycle_theft", "警察局", "機車竊盜點位資訊"],
         "description": "Motorcycle theft in Taipei began in January 2015.",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0026/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0026/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {
         "dag_id": "R0026",
         "start_date": "2021-08-24",
-        "schedule_interval": "30 0 11 * *",
+        "schedule_interval": "30 12 3,24 * *",
         "catchup": false,
         "tags": ["patrol_random_snatch", "警察局", "街頭隨機搶奪點位資訊"],
         "description": "Random snatch in Taipei began in January 2015.",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0027/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0027/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {
         "dag_id": "R0027",
         "start_date": "2021-08-24",
-        "schedule_interval": "0 2 11 * *",
+        "schedule_interval": "0 13 3,24 * *",
         "catchup": false,
         "tags": ["patrol_random_robber", "警察局", "街頭隨機強盜"],
         "description": "Random robber in Taipei began in January 2015.",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0031/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0031/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {
         "dag_id": "R0031",
         "start_date": "2021-08-24",
-        "schedule_interval": "0 4 14 * *",
+        "schedule_interval": "30 13 3,24 * *",
         "catchup": false,
         "tags": ["patrol_police_station", "警察局", "警察局名稱及地址"],
         "description": "Inventory of unutilized municipal buildings in Taipei City.",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0033/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0033/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {  
         "dag_id": "R0033",
         "start_date": "2021-08-24",
-        "schedule_interval": "30 18 2 * *",
+        "schedule_interval": "0 14 3,24 * *",
         "catchup": false,
         "tags": ["patrol_fire_rescure", "消防局", "火災搶救困難地區"],
         "description": "Difficult area for fire rescue.", 

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0033_1/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0033_1/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {
         "dag_id": "R0033-1",
         "start_date": "2021-08-24",
-        "schedule_interval": "30 18 15 * *",
+        "schedule_interval": "30 14 3,24 * *",
         "catchup": false,
         "tags": ["patrol_fire_brigade", "消防局", "消防局各分隊駐地"],
         "description": "Locations of the Taipei City Fire Department's brigades",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0033_2/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0033_2/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {
         "dag_id": "R0033-2",
         "start_date": "2021-08-24",
-        "schedule_interval": "0 19 15 * *",
+        "schedule_interval": "0 15 3,24 * *",
         "catchup": false,
         "tags": ["patrol_fire_disqualified", "消防局", "消防安全檢查重大不合格場所"],
         "description": "",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0037_1/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0037_1/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {  
         "dag_id": "R0037_1",
         "start_date": "2024-06-05",
-        "schedule_interval": "0 3 22 12 *",
+        "schedule_interval": "30 15 3,24 * *",
         "catchup": false,
         "tags": ["patrol_flood_78_8", "工務局", "降雨積水模擬圖"],
         "description": "Possible flooding areas under heavy short-duration rainfall conditions (78.8 mm/h) in Taipei City.", 

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0037_2/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0037_2/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {  
         "dag_id": "R0037_2",
         "start_date": "2024-06-05",
-        "schedule_interval": "10 3 22 12 *",
+        "schedule_interval": "0 16 3,24 * *",
         "catchup": false,
         "tags": ["patrol_flood_100", "工務局", "降雨積水模擬圖"],
         "description": "Possible flooding areas under heavy short-duration rainfall conditions (100 mm/h) in Taipei City.", 

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0037_3/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0037_3/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {  
         "dag_id": "R0037_3",
         "start_date": "2024-06-05",
-        "schedule_interval": "20 3 22 12 *",
+        "schedule_interval": "30 16 3,24 * *",
         "catchup": false,
         "tags": ["patrol_flood_130", "工務局", "降雨積水模擬圖"],
         "description": "Possible flooding areas under heavy short-duration rainfall conditions (130 mm/h) in Taipei City.", 

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0042/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0042/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {  
         "dag_id": "R0042",
         "start_date": "2021-11-17",
-        "schedule_interval": "0 3 1 4 *",
+        "schedule_interval": "0 17 3,24 * *",
         "catchup": false,
         "tags": ["traffic_accident_location", "警察局", "道路交通事故斑點圖"],
         "description": "Announced once a year, the time and location of A1, A2 traffic accidents in Taipei City", 

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0054/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0054/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {  
         "dag_id": "R0054",
         "start_date": "2024-06-01",
-        "schedule_interval": "40 3 9 6,12 *",
+        "schedule_interval": "30 17 3,24 * *",
         "catchup": false,
         "tags": ["urbn_landuse_master_plan", "都市計畫主要使用分區", "都發局"],
         "description": "Taipei City Urban Planning Major Plan Land Use Data.", 

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0056/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0056/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {
         "dag_id": "R0056",
         "start_date": "2021-11-17",
-        "schedule_interval": "0 3 5 * *",
+        "schedule_interval": "0 18 3,24 * *",
         "catchup": false,
         "tags": ["building_publand", "地政局", "公有土地"],
         "description": "Locations of public land in Taipei City",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0057/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0057/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {
         "dag_id": "R0057",
         "start_date": "2021-11-17",
-        "schedule_interval": "0 4 25 * *",
+        "schedule_interval": "30 18 3,24 * *",
         "catchup": false,
         "tags": ["building_permit", "都發局", "當年度建造執照"],
         "description": "Building permits of this year.",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0058/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0058/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {
         "dag_id": "R0058",
         "start_date": "2021-11-17",
-        "schedule_interval": "0 5 25 * *",
+        "schedule_interval": "0 19 3,24 * *",
         "catchup": false,
         "tags": ["building_permit_history", "都發局", "歷年(除本年度)建造執照"],
         "description": "Building permits excluding this year from data.taipei.",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0061/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0061/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {
         "dag_id": "R0061",
         "start_date": "2021-11-17",
-        "schedule_interval": "0 20 20 * *",
+        "schedule_interval": "30 19 3,24 * *",
         "catchup": false,
         "tags": ["building_social_house", "都發局", "社會住宅興建進度資料"],
         "description": "Social housing construction progress.",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0062/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0062/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {
         "dag_id": "R0062",
         "start_date": "2024-06-26",
-        "schedule_interval": "00 19 3 * *",
+        "schedule_interval": "0 20 3,24 * *",
         "catchup": false,
         "tags": ["building_renewarea_10", "都發局", "公劃更新地區(依都更條例)"],
         "description": "",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0063/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0063/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {
         "dag_id": "R0063",
         "start_date": "2024-06-26",
-        "schedule_interval": "10 19 3 * *",
+        "schedule_interval": "30 20 3,24 * *",
         "catchup": false,
         "tags": ["building_renewunit_12", "都發局", "公劃地區內事業(權變案件)"],
         "description": "",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0064/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0064/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {
         "dag_id": "R0064",
         "start_date": "2024-06-26",
-        "schedule_interval": "20 19 3 * *",
+        "schedule_interval": "0 21 3,24 * *",
         "catchup": false,
         "tags": ["building_renewunit_20", "都發局", "公告自劃單元(自劃事業(權變)計劃案件)"],
         "description": "",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0065/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0065/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {
         "dag_id": "R0065",
         "start_date": "2024-06-26",
-        "schedule_interval": "30 19 3 * *",
+        "schedule_interval": "30 21 3,24 * *",
         "catchup": false,
         "tags": ["building_renewunit_30", "都發局", "核准自劃單元(自劃事業(權變)計劃案件)"],
         "description": "",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0066/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0066/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {
         "dag_id": "R0066",
         "start_date": "2024-06-26",
-        "schedule_interval": "40 19 3 * *",
+        "schedule_interval": "0 12 4,25 * *",
         "catchup": false,
         "tags": ["building_renewarea_40", "都發局", "都市計畫劃定更新地區"],
         "description": "",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0067/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0067/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {  
         "dag_id": "R0067",
         "start_date": "2021-11-17",
-        "schedule_interval": "0 7 7 3,6,9,12 *",
+        "schedule_interval": "30 12 4,25 * *",
         "catchup": false,
         "tags": ["building_unsued_land", "財政局", "市有尚未利用土地"],
         "description": "Unused municipal land.", 

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0068/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0068/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {
         "dag_id": "R0068",
         "start_date": "2021-11-17",
-        "schedule_interval": "0 1 16 3,9 *",
+        "schedule_interval": "0 13 4,25 * *",
         "catchup": false,
         "tags": ["building_unsued_public", "財政局", "市有尚未利用建物"],
         "description": "Inventory of unutilized municipal buildings in Taipei City.",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0069/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0069/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {
         "dag_id": "R0069",
         "start_date": "2021-11-17",
-        "schedule_interval": "0 2 16 3,9 *",
+        "schedule_interval": "30 13 4,25 * *",
         "catchup": false,
         "tags": ["building_unsued_nonpublic", "財政局", "市有非公用閒置建物"],
         "description": "Inventory of non-public unutilized municipal buildings managed by the Taipei City Government Finance Bureau",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0075/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0075/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {
         "dag_id": "R0075",
         "start_date": "2021-11-19",
-        "schedule_interval": "0 1 20 1,4,7,10 *",
+        "schedule_interval": "0 14 4,25 * *",
         "catchup": false,
         "tags": ["fire_hydrant_location", "北水處", "消防栓點位"],
         "description": "Locations of fire hydrant distribution points in the Greater Taipei area, including 7 districts: Taipei City, Sanchong District, Zhonghe District, Yonghe District, Xindian District, and Xizhi District of New Taipei City",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0076/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0076/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {  
         "dag_id": "R0076",
         "start_date": "2021-11-22",
-        "schedule_interval": "* * 1 * *",
+        "schedule_interval": "30 14 4,25 * *",
         "catchup": false,
         "tags": ["work_nether", "Nether", "data.taipei", "工務局", "人行地下道", "車行地下道"],
         "description": "Nether infomation of Taipei City from data.taipei.", 

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0081/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0081/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {
         "dag_id": "R0081",
         "start_date": "2024-04-11",
-        "schedule_interval": "0 4 21 * *",
+        "schedule_interval": "0 15 4,25 * *",
         "catchup": false,
         "tags": ["work_pumping_station_location", "工務局", "抽水站"],
         "description": "Taiepi city pumping station locations.",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0082/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0082/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {
         "dag_id": "R0082",
         "start_date": "2024-04-11",
-        "schedule_interval": "0 5 21 * *",
+        "schedule_interval": "30 15 4,25 * *",
         "catchup": false,
         "tags": ["work_floodgate_location", "工務局", "閘閥門"],
         "description": "Taiepi city gate or valve locations.",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0083/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0083/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {  
         "dag_id": "R0083",
         "start_date": "2021-12-21",
-        "schedule_interval": "0 6 25 3,9 *",
+        "schedule_interval": "0 16 4,25 * *",
         "catchup": false,
         "tags": ["work_sewer_location", "工務局", "水利處雨水下水道水位監測站"],
         "description": "Rainwater sewerage level monitoring stations location.", 

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0085/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0085/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {  
         "dag_id": "R0085",
         "start_date": "2021-12-21",
-        "schedule_interval": "0 5 25 3,9 *",
+        "schedule_interval": "30 16 4,25 * *",
         "catchup": false,
         "tags": ["work_rainfall_station_location", "工務局", "水利處雨量站點位"],
         "description": "Rainfall stations location.", 

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0086/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0086/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {  
         "dag_id": "R0086",
         "start_date": "2021-12-20",
-        "schedule_interval": "0 0 1 * *",
+        "schedule_interval": "0 17 4,25 * *",
         "catchup": false,
         "tags": ["cwb_rainfall_station_location", "中央氣象署", "無人自動站"],
         "description": "Location of auto weather stations.", 

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/accessible_facilities/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/accessible_facilities/job_config.json
@@ -2,7 +2,7 @@
   "dag_infos": {
     "dag_id": "accessible_facilities",
     "start_date": "2025-06-25",
-    "schedule_interval": "@monthly",
+    "schedule_interval": "0 17 6,27 * *",
     "catchup": false,
     "tags": [
       "accessible_facilities",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/aed_locations/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/aed_locations/job_config.json
@@ -2,7 +2,7 @@
   "dag_infos": {
     "dag_id": "aed_locations",
     "start_date": "2024-12-10",
-    "schedule_interval": "0 20 19 * *",
+    "schedule_interval": "30 17 6,27 * *",
     "catchup": false,
     "tags": [
       "aed",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/bike_theft/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/bike_theft/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {
         "dag_id": "bike_theft",
         "start_date": "2021-08-24",
-        "schedule_interval": "30 23 10 * *",
+        "schedule_interval": "30 17 4,25 * *",
         "catchup": false,
         "tags": ["patrol_bike_theft", "警察局", "自行車竊盜點位資訊"],
         "description": "Car theft in Taipei began in January 2015.",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/cooling_point/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/cooling_point/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {  
         "dag_id": "cooling_point",
         "start_date": "2025-06-25",
-        "schedule_interval": "@monthly",
+        "schedule_interval": "0 18 4,25 * *",
         "catchup": false,
         "tags": ["cooling_point_tpe", "臺北市涼適點", "市府資料平台"],
         "description": "臺北市轄內戶外及室內涼適場所",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/dependency_ratio_and_aging_index/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/dependency_ratio_and_aging_index/job_config.json
@@ -2,7 +2,7 @@
   "dag_infos": {
     "dag_id": "dependency_ratio_and_aging_index",
     "start_date": "2025-02-11",
-    "schedule_interval": "0 3 25 12 *",
+    "schedule_interval": "0 18 6,27 * *",
     "catchup": false,
     "tags": [
       "dependency_ratio_and_aging_index",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/elderly_club/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/elderly_club/job_config.json
@@ -2,7 +2,7 @@
 	"dag_infos": {
 		"dag_id": "elderly_club",
 		"start_date": "2025-07-07",
-		"schedule_interval": "0 20 19 * *",
+		"schedule_interval": "30 18 6,27 * *",
 		"catchup": false,
 		"tags": [
 			"elderly_club",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/employment_age_structure/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/employment_age_structure/job_config.json
@@ -2,7 +2,7 @@
   "dag_infos": {
     "dag_id": "employment_age_structure",
     "start_date": "2025-02-11",
-    "schedule_interval": "0 3 25 12 *",
+    "schedule_interval": "0 19 6,27 * *",
     "catchup": false,
     "tags": [
       "employment_age_structure",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/energy_saving_coaching_situation_tpe/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/energy_saving_coaching_situation_tpe/job_config.json
@@ -2,7 +2,7 @@
 	"dag_infos": {
 		"dag_id": "energy_saving_coaching_situation_tpe",
 		"start_date": "2024-12-31",
-		"schedule_interval": "0 20 19 * *",
+		"schedule_interval": "30 19 6,27 * *",
 		"catchup": false,
 		"tags": [
 			"energy_saving_coaching_situation_tpe",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/energy_saving_coaching_situation_tpe_gov/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/energy_saving_coaching_situation_tpe_gov/job_config.json
@@ -2,7 +2,7 @@
 	"dag_infos": {
 		"dag_id": "energy_saving_coaching_situation_tpe_gov",
 		"start_date": "2024-12-31",
-		"schedule_interval": "0 20 19 * *",
+		"schedule_interval": "0 20 6,27 * *",
 		"catchup": false,
 		"tags": [
 			"energy_saving_coaching_situation_tpe_gov",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/env_srv_energy_subsidy/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/env_srv_energy_subsidy/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {
         "dag_id": "env_srv_energy_subsidy",
         "start_date": "2024-05-30",
-        "schedule_interval": "0 3 24 6,12 *",
+        "schedule_interval": "30 20 6,27 * *",
         "catchup": false,
         "tags": ["env_srv_energy_subsidy", "產業局", "臺北市服務業汰換節能設備補助相關資訊"],
         "description": "Taipei city's air raid shelter list.",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/flu_hospitals_tpe/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/flu_hospitals_tpe/job_config.json
@@ -2,7 +2,7 @@
   "dag_infos": {
     "dag_id": "flu_hospitals_tpe",
     "start_date": "2025-02-17",
-    "schedule_interval": "@monthly",
+    "schedule_interval": "30 18 4,25 * *",
     "catchup": false,
     "tags": ["flu_hospitals_tpe", "衛生局"],
     "description": "This dataset provides annual statistics on Taipei City's flu vaccination hospitals, including their locations, contact information, and available vaccines.",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/friendly_store/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/friendly_store/job_config.json
@@ -2,7 +2,7 @@
   "dag_infos": {
     "dag_id": "friendly_store",
     "start_date": "2024-12-10",
-    "schedule_interval": "0 20 19 * *",
+    "schedule_interval": "0 21 6,27 * *",
     "catchup": false,
     "tags": [
       "friendly_store",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/general_hotel_registry/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/general_hotel_registry/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {  
         "dag_id": "general_hotel_registry",
         "start_date": "2025-06-25",
-        "schedule_interval": "@monthly",
+        "schedule_interval": "0 19 4,25 * *",
         "catchup": false,
         "tags": ["general_hotel_registry_tpe", "觀光旅遊局", "臺北市合法一般旅館名冊"],
         "description": "", 

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/li_age_population_tpe/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/li_age_population_tpe/job_config.json
@@ -2,7 +2,7 @@
   "dag_infos": {
     "dag_id": "li_age_population_tpe",
     "start_date": "2024-12-10",
-    "schedule_interval": "0 20 19 * *",
+    "schedule_interval": "30 21 6,27 * *",
     "catchup": false,
     "tags": [
       "li_age_population_tpe",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/long_term/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/long_term/job_config.json
@@ -2,7 +2,7 @@
   "dag_infos": {
     "dag_id": "long_term",
     "start_date": "2025-06-25",
-    "schedule_interval": "@monthly",
+    "schedule_interval": "30 19 4,25 * *",
     "catchup": false,
     "tags": [
       "long_term",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/merge_crime_type_by_dist/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/merge_crime_type_by_dist/job_config.json
@@ -2,7 +2,7 @@
   "dag_infos": {
     "dag_id": "merge_crime_type_by_dist",
     "start_date": "2025-06-25",
-    "schedule_interval": "@monthly",
+    "schedule_interval": "0 12 7,28 * *",
     "catchup": false,
     "tags": [
       "merge_crime_type_by_dist",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/moenv_public_toilet_tpe/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/moenv_public_toilet_tpe/job_config.json
@@ -2,7 +2,7 @@
 	"dag_infos": {
 		"dag_id": "moenv_public_toilet_tpe",
 		"start_date": "2025-06-25",
-		"schedule_interval": "@monthly",
+		"schedule_interval": "0 20 4,25 * *",
 		"catchup": false,
 		"tags": [
 			"moenv_public_toilet_tpe",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/population_age_distribution_monthly/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/population_age_distribution_monthly/job_config.json
@@ -2,7 +2,7 @@
   "dag_infos": {
     "dag_id": "population_age_distribution_monthly",
     "start_date": "2025-02-17",
-    "schedule_interval": "0 4 14 * *",
+    "schedule_interval": "30 20 4,25 * *",
     "catchup": false,
     "tags": ["population_age_distribution_monthly_tpe", "主計處"],
     "description": "This dataset provides monthly statistics on Taipei City's population age distribution, including young, working-age, and elderly populations, their proportions, dependency ratios, and aging index.",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/school_reconstruction/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/school_reconstruction/job_config.json
@@ -2,7 +2,7 @@
   "dag_infos": {
     "dag_id": "school_reconstruction",
     "start_date": "2025-11-17",
-    "schedule_interval": "@monthly",
+    "schedule_interval": "0 21 4,25 * *",
     "catchup": false,
     "tags": [
       "school_reconstruction_tpe",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/sea_sand_houses_tpe/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/sea_sand_houses_tpe/job_config.json
@@ -2,7 +2,7 @@
 	"dag_infos": {
 		"dag_id": "sea_sand_houses_tpe",
 		"start_date": "2024-12-10",
-		"schedule_interval": "0 20 19 * *",
+		"schedule_interval": "30 12 7,28 * *",
 		"catchup": false,
 		"tags": [
 			"sea_sand_houses_tpe",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/smoking_area/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/smoking_area/job_config.json
@@ -2,7 +2,7 @@
   "dag_infos": {
     "dag_id": "smoking_area",
     "start_date": "2026-05-04",
-    "schedule_interval": "0 20 19 * *",
+    "schedule_interval": "30 21 4,25 * *",
     "catchup": false,
     "tags": [
       "smoking_area",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/tourist_attractions/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/tourist_attractions/job_config.json
@@ -2,7 +2,7 @@
   "dag_infos": {
     "dag_id": "tourist_attractions",
     "start_date": "2025-06-25",
-    "schedule_interval": "@monthly",
+    "schedule_interval": "0 13 7,28 * *",
     "catchup": false,
     "tags": [
       "tourist_attractions",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/yearly_death_cause_etl/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/yearly_death_cause_etl/job_config.json
@@ -2,7 +2,7 @@
   "dag_infos": {
     "dag_id": "yearly_death_cause_etl",
     "start_date": "2025-02-17",
-    "schedule_interval": "@yearly",
+    "schedule_interval": "0 12 5,26 * *",
     "catchup": false,
     "tags": ["yearly_death_cause_etl_tpe", "主計處"],
     "description": "This dataset provides annual statistics on Taipei City's death causes, including major causes of death, their proportions, and trends over the years.",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/youth_enterpreneurship_financing_loan_tpe/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/youth_enterpreneurship_financing_loan_tpe/job_config.json
@@ -2,7 +2,7 @@
 	"dag_infos": {
 		"dag_id": "youth_enterpreneurship_financing_loan_tpe",
 		"start_date": "2024-12-10",
-		"schedule_interval": "0 20 19 * *",
+		"schedule_interval": "30 13 7,28 * *",
 		"catchup": false,
 		"tags": [
 			"youth_enterpreneurship_financing_loan_tpe",

--- a/Taipei-City-Dashboard-DE/dags/proj_new_taipei_city_dashboard/accessible_facilities/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_new_taipei_city_dashboard/accessible_facilities/job_config.json
@@ -2,7 +2,7 @@
   "dag_infos": {
     "dag_id": "accessible_facilities",
     "start_date": "2025-06-25",
-    "schedule_interval": "@monthly",
+    "schedule_interval": "0 14 7,28 * *",
     "catchup": false,
     "tags": [
       "accessible_facilities",

--- a/Taipei-City-Dashboard-DE/dags/proj_new_taipei_city_dashboard/aed_locations/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_new_taipei_city_dashboard/aed_locations/job_config.json
@@ -2,7 +2,7 @@
   "dag_infos": {
     "dag_id": "aed_locations_metrotaipei",
     "start_date": "2024-12-10",
-    "schedule_interval": "0 20 19 * *",
+    "schedule_interval": "30 12 5,26 * *",
     "catchup": false,
     "tags": [
       "aed",

--- a/Taipei-City-Dashboard-DE/dags/proj_new_taipei_city_dashboard/dependency_ratio_and_aging_index/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_new_taipei_city_dashboard/dependency_ratio_and_aging_index/job_config.json
@@ -2,7 +2,7 @@
   "dag_infos": {
     "dag_id": "dependency_ratio_and_aging_index",
     "start_date": "2025-02-11",
-    "schedule_interval": "0 3 25 12 *",
+    "schedule_interval": "30 14 7,28 * *",
     "catchup": false,
     "tags": [
       "dependency_ratio_and_aging_index",

--- a/Taipei-City-Dashboard-DE/dags/proj_new_taipei_city_dashboard/elderly_club/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_new_taipei_city_dashboard/elderly_club/job_config.json
@@ -2,7 +2,7 @@
   "dag_infos": {
     "dag_id": "elderly_club",
     "start_date": "2025-07-07",
-    "schedule_interval": "@monthly",
+    "schedule_interval": "0 13 5,26 * *",
     "catchup": false,
     "tags": ["elderly_club", "新北市", "New-Taipei-City", "新北市銀髮俱樂部"],
     "description": "",

--- a/Taipei-City-Dashboard-DE/dags/proj_new_taipei_city_dashboard/employment_age_structure/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_new_taipei_city_dashboard/employment_age_structure/job_config.json
@@ -2,7 +2,7 @@
   "dag_infos": {
     "dag_id": "employment_age_structure",
     "start_date": "2025-02-11",
-    "schedule_interval": "0 3 25 12 *",
+    "schedule_interval": "0 15 7,28 * *",
     "catchup": false,
     "tags": [
       "employment_age_structure",

--- a/Taipei-City-Dashboard-DE/dags/proj_new_taipei_city_dashboard/fire_narrow_street/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_new_taipei_city_dashboard/fire_narrow_street/job_config.json
@@ -2,7 +2,7 @@
   "dag_infos": {
     "dag_id": "fire_narrow_street",
     "start_date": "2025-07-07",
-    "schedule_interval": "@monthly",
+    "schedule_interval": "30 13 5,26 * *",
     "catchup": false,
     "tags": ["fire_narrow_street", "新北市", "New-Taipei-City", "狹小巷道"],
     "description": "",

--- a/Taipei-City-Dashboard-DE/dags/proj_new_taipei_city_dashboard/flu_hospitals_ntpe/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_new_taipei_city_dashboard/flu_hospitals_ntpe/job_config.json
@@ -2,7 +2,7 @@
   "dag_infos": {
     "dag_id": "flu_hospitals_ntpe",
     "start_date": "2025-06-25",
-    "schedule_interval": "@monthly",
+    "schedule_interval": "30 15 7,28 * *",
     "catchup": false,
     "tags": [
       "flu_hospitals_ntpe",

--- a/Taipei-City-Dashboard-DE/dags/proj_new_taipei_city_dashboard/general_hotel_registry/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_new_taipei_city_dashboard/general_hotel_registry/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {  
         "dag_id": "general_hotel_registry",
         "start_date": "2025-06-25",
-        "schedule_interval": "@monthly",
+        "schedule_interval": "0 14 5,26 * *",
         "catchup": false,
         "tags": ["general_hotel_registry_ntpe", "觀光旅遊局", "新北市合法一般旅館名冊"],
         "description": "", 

--- a/Taipei-City-Dashboard-DE/dags/proj_new_taipei_city_dashboard/long_term/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_new_taipei_city_dashboard/long_term/job_config.json
@@ -2,7 +2,7 @@
   "dag_infos": {
     "dag_id": "long_term",
     "start_date": "2024-12-10",
-    "schedule_interval": "0 20 19 * *",
+    "schedule_interval": "30 14 5,26 * *",
     "catchup": false,
     "tags": [
       "long_term",

--- a/Taipei-City-Dashboard-DE/dags/proj_new_taipei_city_dashboard/merge_crime_type_by_dist/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_new_taipei_city_dashboard/merge_crime_type_by_dist/job_config.json
@@ -2,7 +2,7 @@
   "dag_infos": {
     "dag_id": "merge_crime_type_by_dist",
     "start_date": "2025-06-30",
-    "schedule_interval": "@monthly",
+    "schedule_interval": "0 15 5,26 * *",
     "catchup": false,
     "tags": ["merge_crime_type_by_dist", "新北市", "New-Taipei-City", "犯罪資料"],
     "description": "",

--- a/Taipei-City-Dashboard-DE/dags/proj_new_taipei_city_dashboard/moenv_public_toilet_ntpe/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_new_taipei_city_dashboard/moenv_public_toilet_ntpe/job_config.json
@@ -2,7 +2,7 @@
 	"dag_infos": {
 		"dag_id": "moenv_public_toilet_ntpe",
 		"start_date": "2025-06-25",
-		"schedule_interval": "@monthly",
+		"schedule_interval": "30 15 5,26 * *",
 		"catchup": false,
 		"tags": [
 			"moenv_public_toilet_ntpe",

--- a/Taipei-City-Dashboard-DE/dags/proj_new_taipei_city_dashboard/population_age_distribution_monthly/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_new_taipei_city_dashboard/population_age_distribution_monthly/job_config.json
@@ -2,7 +2,7 @@
   "dag_infos": {
     "dag_id": "population_age_distribution_monthly",
     "start_date": "2025-02-17",
-    "schedule_interval": "0 4 14 * *",
+    "schedule_interval": "0 16 7,28 * *",
     "catchup": false,
     "tags": ["population_age_distribution_monthly_new_tpe", "主計處"],
     "description": "This dataset provides monthly statistics on New Taipei City's population age distribution, including young, working-age, and elderly populations, their proportions, dependency ratios, and aging index.",

--- a/Taipei-City-Dashboard-DE/dags/proj_new_taipei_city_dashboard/tourist_attractions/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_new_taipei_city_dashboard/tourist_attractions/job_config.json
@@ -2,7 +2,7 @@
   "dag_infos": {
     "dag_id": "tourist_attractions",
     "start_date": "2025-06-25",
-    "schedule_interval": "@monthly",
+    "schedule_interval": "30 16 7,28 * *",
     "catchup": false,
     "tags": [
       "tourist_attractions",

--- a/Taipei-City-Dashboard-DE/dags/proj_new_taipei_city_dashboard/urbn_air_raid_shelter/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_new_taipei_city_dashboard/urbn_air_raid_shelter/job_config.json
@@ -2,7 +2,7 @@
   "dag_infos": {
     "dag_id": "urbn_air_raid_shelter",
     "start_date": "2025-07-07",
-    "schedule_interval": "@monthly",
+    "schedule_interval": "0 16 5,26 * *",
     "catchup": false,
     "tags": ["urbn_air_raid_shelter", "新北市", "New-Taipei-City", "防空避難處所"],
     "description": "",

--- a/Taipei-City-Dashboard-DE/dags/proj_new_taipei_city_dashboard/yearly_death_cause_etl/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_new_taipei_city_dashboard/yearly_death_cause_etl/job_config.json
@@ -2,7 +2,7 @@
   "dag_infos": {
     "dag_id": "yearly_death_cause_etl",
     "start_date": "2025-06-25",
-    "schedule_interval": "@yearly",
+    "schedule_interval": "0 17 7,28 * *",
     "catchup": false,
     "tags": [
       "yearly_death_cause_etl",

--- a/Taipei-City-Dashboard-DE/dags/tutorial/simple_template/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/tutorial/simple_template/job_config.json
@@ -2,7 +2,7 @@
     "dag_infos": {
         "dag_id": "template_test",
         "start_date": "2024-03-14",
-        "schedule_interval": "0 0 1 * *",
+        "schedule_interval": "30 16 5,26 * *",
         "catchup": false,
         "tags": ["test", "template", "衛生局", "醫院", "heal_hospital"],
         "description": "A DAG only contain neccesary part for tutorial.",


### PR DESCRIPTION
將 131 個每月以上頻率的 DAG schedule_interval 統一改為:
- 每月執行兩次(first-week + last-week)
- 全部落在 Taipei 20:00-06:00 離峰時段(UTC 12:00-21:59)
- 任兩個 DAG 之間至少間隔 30 分鐘,全域零衝突
- quarterly/yearly 排程一律提升為每月執行
- @once 不調整

對照表(包含中文執行時間說明)位於 .agent/output/schedule_redistribution.csv

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

## Summary

**Issue:** Enter the issue(s) this pull request resolves.

A clear and concise description of this pull request

## Type (Fill in "x" to check)

- [ ] Bug Fix
- [ ] New Feature

## Checklist

Please make sure that all items are checked before submitting this request.

- [ ] Code linter has been run and issues have all been resolved
- [ ] The code has been thoroughly tested and no visible bugs have been introduced
- [ ] The pull request will completely resolve the issue(s) mentioned
- [ ] The pull request only resolves the issue(s) mentioned and nothing more

## Additional context

Add any other context here.
