### PR TITLE
Feature/guzhong team sankey chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ Taipei-City-Dashboard-DE/docker/prod/.env
 *.py[cod]
 
 *.env
+
+# Local agent / tooling state
+.claude/

--- a/Taipei-City-Dashboard-FE/src/dashboardComponent/DashboardComponent.vue
+++ b/Taipei-City-Dashboard-FE/src/dashboardComponent/DashboardComponent.vue
@@ -28,6 +28,7 @@ import BarChartWithGoal from "./components/BarChartWithGoal.vue";
 import IconPercentChart from "./components/IconPercentChart.vue";
 import IndicatorChart from "./components/IndicatorChart.vue";
 import TextUnitChart from "./components/TextUnitChart.vue";
+import SankeyChart from "./components/SankeyChart.vue";
 
 import MapLegendSvg from "./assets/chart/MapLegend.svg";
 import DistrictChartSvg from "./assets/chart/DistrictChart.svg";
@@ -92,6 +93,9 @@ const emits = defineEmits([
 ]);
 
 const activeChart = ref(props.config.chart_config.types[0]);
+const isWide = computed(() =>
+	props.config.chart_config?.types?.includes("SankeyChart") && props.mode === "default"
+);
 const activeCity = computed({
 	get: () => props.activeCity,
 	set: (value) => {
@@ -222,6 +226,8 @@ function returnChartComponent(name, svg) {
 		return svg ? IndicatorChartSvg : IndicatorChart;
 	case "TextUnitChart":
 		return svg ? TextUnitChartSvg : TextUnitChart;
+	case "SankeyChart":
+		return svg ? BarChartSvg : SankeyChart;
 	default:
 		return svg ? MapLegendSvg : MapLegend;
 	}
@@ -239,6 +245,7 @@ function returnChartComponent(name, svg) {
         half: mode === 'half',
         large: mode === 'large',
         preview: mode === 'preview',
+        wide: isWide,
       },
     ]"
     :style="style"
@@ -422,6 +429,7 @@ function returnChartComponent(name, svg) {
         :is="returnChartComponent(item)"
         v-for="item in config.chart_config.types"
         :key="`${props.config.index}-${item}-chart-${item.city}`"
+        :mode="mode"
         :active-chart="activeChart"
         :active-city="activeCity"
         :chart_config="config.chart_config"
@@ -554,6 +562,38 @@ button:hover {
 	max-height: 330px;
 	width: calc(100% - var(--font-m) * 2);
 	max-width: calc(100% - var(--font-m) * 2);
+
+	&.wide {
+		grid-column: span 3;
+		height: 560px;
+		max-height: 560px;
+		justify-content: flex-start;
+		gap: 4px;
+
+		@media (min-width: 1050px) {
+			height: 640px;
+			max-height: 640px;
+		}
+
+		@media (min-width: 1650px) {
+			height: 720px;
+			max-height: 720px;
+		}
+
+		.dashboardcomponent-control {
+			padding: 0;
+		}
+
+		.dashboardcomponent-chart {
+			flex: 1;
+			min-height: 0;
+			height: auto;
+		}
+
+		.dashboardcomponent-footer {
+			margin-top: auto;
+		}
+	}
 	display: flex;
 	flex-direction: column;
 	justify-content: space-between;

--- a/Taipei-City-Dashboard-FE/src/dashboardComponent/components/SankeyChart.vue
+++ b/Taipei-City-Dashboard-FE/src/dashboardComponent/components/SankeyChart.vue
@@ -1,0 +1,727 @@
+<!-- Sankey Chart -->
+<!--
+  Generic Sankey chart type. Domain text/filters/colors driven by chart_config:
+    chart_config.sankey_columns       string[3]  optional column header labels
+    chart_config.sankey_filters       [{field,label}]  data-field-driven dropdowns
+    chart_config.sankey_layer_labels  {raw: pretty}  pretty layer toggle labels
+    chart_config.sankey_color_by      string  field name to color links by
+    chart_config.sankey_color_map     {value: color}  explicit color override
+    chart_config.color                string[]  fallback palette indexed by unique values
+    chart_config.unit                 string  tooltip number suffix
+  Each link in series requires: source, target, value, layer (string).
+  Any extra fields can be referenced by sankey_filters / sankey_color_by.
+  Layout assumes <= 2 distinct layer values forming a chain (col0 → col1 → col2).
+-->
+<script setup>
+import { computed, ref, watch, onMounted, onUnmounted } from "vue";
+
+const props = defineProps([
+	"chart_config",
+	"activeChart",
+	"series",
+	"map_config",
+	"map_filter",
+	"map_filter_on",
+	"mode",
+]);
+
+defineEmits([
+	"filterByParam",
+	"filterByLayer",
+	"clearByParamFilter",
+	"clearByLayerFilter",
+	"fly",
+]);
+
+const NODE_W = 18;
+const GAP = 4;
+const PAD_TOP = 38;
+const PAD_BOTTOM = 6;
+const SVG_W_MIN = 1000;
+const SVG_H_BASE = 420;
+const DEFAULT_MAX_NODES = 25;
+const FALLBACK_COLOR = "#888888";
+const DEFAULT_PALETTE = ["#5b9fe8", "#f59e0b", "#22c55e", "#a855f7", "#ec4899", "#06b6d4"];
+
+const containerRef = ref(null);
+const containerWidth = ref(SVG_W_MIN);
+
+let resizeObserver = null;
+onMounted(() => {
+	if (!containerRef.value || typeof ResizeObserver === "undefined") return;
+	resizeObserver = new ResizeObserver((entries) => {
+		for (const e of entries) {
+			containerWidth.value = e.contentRect.width;
+		}
+	});
+	resizeObserver.observe(containerRef.value);
+});
+onUnmounted(() => {
+	resizeObserver?.disconnect();
+	resizeObserver = null;
+});
+
+const svgWidth = computed(() => Math.max(containerWidth.value, SVG_W_MIN));
+const X = computed(() => {
+	const w = svgWidth.value;
+	return [
+		Math.round(w * 0.121),
+		Math.round(w * 0.4375),
+		Math.round(w * 0.863),
+	];
+});
+
+const rawLinks = computed(() => {
+	const s = props.series;
+	if (!s) return [];
+	if (Array.isArray(s)) {
+		if (s.length && s[0]?.data && Array.isArray(s[0].data)) return s[0].data;
+		return s;
+	}
+	if (s.links && Array.isArray(s.links)) return s.links;
+	return [];
+});
+
+const sankeyColumns = computed(() => props.chart_config?.sankey_columns || []);
+const filterFields = computed(() => props.chart_config?.sankey_filters || []);
+const layerLabelMap = computed(() => props.chart_config?.sankey_layer_labels || {});
+const unit = computed(() => props.chart_config?.unit || "");
+
+function layerLabel(raw) {
+	return layerLabelMap.value[raw] || raw;
+}
+
+const allLayerValues = computed(() => {
+	const seen = new Set();
+	const out = [];
+	for (const l of rawLinks.value) {
+		if (l.layer && !seen.has(l.layer)) {
+			seen.add(l.layer);
+			out.push(l.layer);
+		}
+	}
+	return out;
+});
+
+const colorMap = computed(() => {
+	const field = props.chart_config?.sankey_color_by;
+	if (!field) return null;
+	const explicit = props.chart_config?.sankey_color_map || {};
+	const palette = props.chart_config?.color?.length
+		? props.chart_config.color
+		: DEFAULT_PALETTE;
+	const seen = [];
+	for (const l of rawLinks.value) {
+		const v = l[field];
+		if (v && !seen.includes(v)) seen.push(v);
+	}
+	const m = new Map();
+	seen.forEach((v, i) => {
+		m.set(v, explicit[v] || palette[i % palette.length] || FALLBACK_COLOR);
+	});
+	return m;
+});
+
+function getLinkColor(l) {
+	const m = colorMap.value;
+	if (!m) return FALLBACK_COLOR;
+	const field = props.chart_config?.sankey_color_by;
+	return m.get(l[field]) || FALLBACK_COLOR;
+}
+
+const filterValues = ref({});
+
+watch(
+	filterFields,
+	(fields) => {
+		for (const f of fields) {
+			if (!(f.field in filterValues.value)) {
+				filterValues.value[f.field] = "全部";
+			}
+		}
+	},
+	{ immediate: true, deep: true }
+);
+
+const filterOptionsByField = computed(() => {
+	const out = {};
+	for (const f of filterFields.value) {
+		const seen = new Set();
+		const list = [];
+		for (const l of rawLinks.value) {
+			const v = l[f.field];
+			if (v !== undefined && v !== null && v !== "" && !seen.has(v)) {
+				seen.add(v);
+				list.push(v);
+			}
+		}
+		list.sort();
+		out[f.field] = ["全部", ...list];
+	}
+	return out;
+});
+
+const selectedLayer = ref("全部");
+const tableLayer = ref("");
+const hoveredTooltip = ref(null);
+
+watch(
+	allLayerValues,
+	(layers) => {
+		if (!tableLayer.value && layers.length) tableLayer.value = layers[0];
+	},
+	{ immediate: true }
+);
+
+const filteredLinks = computed(() => {
+	let links = rawLinks.value;
+	// Per-field filter: only drop links where field is present AND non-matching.
+	// Links lacking the field are kept (filter is silent for them) so a field
+	// that only exists on one layer doesn't wipe out the other layer.
+	for (const f of filterFields.value) {
+		const v = filterValues.value[f.field];
+		if (!v || v === "全部") continue;
+		links = links.filter((l) => {
+			const lv = l[f.field];
+			if (lv === undefined || lv === null || lv === "") return true;
+			return lv === v;
+		});
+	}
+	// Cascade across the 2-layer chain so the unfiltered layer narrows to
+	// only links that connect to the filtered layer's surviving nodes.
+	const layers = allLayerValues.value;
+	if (layers.length === 2) {
+		const [lA, lB] = layers;
+		const aLinks = links.filter((l) => l.layer === lA);
+		const bLinks = links.filter((l) => l.layer === lB);
+		const aTargets = new Set(aLinks.map((l) => l.target));
+		const bSources = new Set(bLinks.map((l) => l.source));
+		const cascadedA = bLinks.length > 0
+			? aLinks.filter((l) => bSources.has(l.target))
+			: aLinks;
+		const cascadedB = aLinks.length > 0
+			? bLinks.filter((l) => aTargets.has(l.source))
+			: bLinks;
+		return [...cascadedA, ...cascadedB];
+	}
+	return links;
+});
+
+const tableRows = computed(() => {
+	const links = filteredLinks.value.filter((l) => l.layer === tableLayer.value);
+	return links
+		.filter((l) => (l.value || 0) > 0)
+		.sort((a, b) => (b.value || 0) - (a.value || 0))
+		.slice(0, 200);
+});
+
+const layout = computed(() =>
+	buildLayout(filteredLinks.value, selectedLayer.value, X.value, allLayerValues.value)
+);
+
+const svgHeight = computed(() => {
+	const maxNodes = Math.max(
+		layout.value.nodes0.length,
+		layout.value.nodes1.length,
+		layout.value.nodes2.length,
+		1
+	);
+	return Math.max(SVG_H_BASE, maxNodes * 30 + 80);
+});
+
+function buildLayout(links, layerFilter, Xpos, layerVals) {
+	const layerA = layerVals[0];
+	const layerB = layerVals[1];
+
+	const includeA = layerA && (layerFilter === "全部" || layerFilter === layerA);
+	const includeB = layerB && (layerFilter === "全部" || layerFilter === layerB);
+
+	const upMid = includeA ? links.filter((l) => l.layer === layerA) : [];
+	const midDown = includeB ? links.filter((l) => l.layer === layerB) : [];
+
+	const flow0 = new Map();
+	const flow1mid = new Map();
+	const flow1down = new Map();
+	const flow2 = new Map();
+
+	for (const l of upMid) {
+		const v = l.value || 0;
+		if (v <= 0) continue;
+		flow0.set(l.source, (flow0.get(l.source) || 0) + v);
+		flow1mid.set(l.target, (flow1mid.get(l.target) || 0) + v);
+	}
+	for (const l of midDown) {
+		const v = l.value || 0;
+		if (v <= 0) continue;
+		flow1down.set(l.source, (flow1down.get(l.source) || 0) + v);
+		flow2.set(l.target, (flow2.get(l.target) || 0) + v);
+	}
+
+	const flow1 = new Map();
+	for (const [k, v] of flow1mid) flow1.set(k, v);
+	for (const [k, v] of flow1down) flow1.set(k, Math.max(flow1.get(k) || 0, v));
+
+	const configured = Number(props.chart_config?.sankey_max_nodes);
+	const topN = Number.isFinite(configured) && configured > 0 ? configured : DEFAULT_MAX_NODES;
+
+	function topNodes(flowMap) {
+		return [...flowMap.entries()]
+			.sort((a, b) => b[1] - a[1])
+			.slice(0, topN);
+	}
+
+	const top0 = topNodes(flow0);
+	const top1 = topNodes(flow1);
+	const top2 = topNodes(flow2);
+	const set0 = new Set(top0.map(([n]) => n));
+	const set1 = new Set(top1.map(([n]) => n));
+	const set2 = new Set(top2.map(([n]) => n));
+
+	const maxNodes = Math.max(top0.length, top1.length, top2.length, 1);
+	const dynamicH = Math.max(SVG_H_BASE, maxNodes * 30 + 80);
+	const availableH = dynamicH - PAD_TOP - PAD_BOTTOM;
+
+	function positionNodes(topList, xPos) {
+		if (topList.length === 0) return [];
+		const total = topList.reduce((s, [, v]) => s + v, 0);
+		const gaps = GAP * (topList.length - 1);
+		const fillH = availableH - gaps;
+		let y = PAD_TOP;
+		return topList.map(([name, flow]) => {
+			const h = Math.max(3, (flow / total) * fillH);
+			const node = { name, flow, x: xPos, y, h };
+			y += h + GAP;
+			return node;
+		});
+	}
+
+	const nodes0 = positionNodes(top0, Xpos[0]);
+	const nodes1 = positionNodes(top1, Xpos[1]);
+	const nodes2 = positionNodes(top2, Xpos[2]);
+	const map0 = new Map(nodes0.map((n) => [n.name, n]));
+	const map1 = new Map(nodes1.map((n) => [n.name, n]));
+	const map2 = new Map(nodes2.map((n) => [n.name, n]));
+
+	function aggLinks(rawLinksArg, srcSet, tgtSet) {
+		const agg = new Map();
+		for (const l of rawLinksArg) {
+			if (!srcSet.has(l.source) || !tgtSet.has(l.target)) continue;
+			const v = l.value || 0;
+			if (v <= 0) continue;
+			const key = `${l.source}|${l.target}`;
+			const entry = agg.get(key) || {
+				source: l.source,
+				target: l.target,
+				value: 0,
+				_origin: l,
+			};
+			entry.value += v;
+			agg.set(key, entry);
+		}
+		return [...agg.values()].sort((a, b) => b.value - a.value);
+	}
+
+	const linksUM = aggLinks(upMid, set0, set1);
+	const linksMD = aggLinks(midDown, set1, set2);
+
+	const usedR0 = new Map(nodes0.map((n) => [n.name, 0]));
+	const usedL1 = new Map(nodes1.map((n) => [n.name, 0]));
+	const usedR1 = new Map(nodes1.map((n) => [n.name, 0]));
+	const usedL2 = new Map(nodes2.map((n) => [n.name, 0]));
+
+	function linkPx(val, nodeFlow, nodeH) {
+		return Math.max(1, (val / nodeFlow) * nodeH);
+	}
+
+	function bezierPath(srcNode, srcOff, tgtNode, tgtOff, lh, color, tip) {
+		const x1 = srcNode.x + NODE_W;
+		const y1 = srcNode.y + srcOff;
+		const x2 = tgtNode.x;
+		const y2 = tgtNode.y + tgtOff;
+		const mx = (x1 + x2) / 2;
+		return {
+			d: [
+				`M ${x1} ${y1}`,
+				`C ${mx} ${y1} ${mx} ${y2} ${x2} ${y2}`,
+				`L ${x2} ${y2 + lh}`,
+				`C ${mx} ${y2 + lh} ${mx} ${y1 + lh} ${x1} ${y1 + lh}`,
+				"Z",
+			].join(" "),
+			fill: color,
+			tip,
+		};
+	}
+
+	function tipText(l) {
+		const num = (l.value || 0).toLocaleString();
+		const suffix = unit.value ? ` ${unit.value}` : "";
+		return `${l.source} → ${l.target}：${num}${suffix}`;
+	}
+
+	const paths = [];
+	for (const l of linksUM) {
+		const src = map0.get(l.source);
+		const tgt = map1.get(l.target);
+		if (!src || !tgt) continue;
+		const lh = Math.min(
+			linkPx(l.value, flow0.get(l.source) || l.value, src.h),
+			linkPx(l.value, flow1mid.get(l.target) || l.value, tgt.h)
+		);
+		const color = getLinkColor(l._origin || l);
+		paths.push(
+			bezierPath(src, usedR0.get(l.source), tgt, usedL1.get(l.target), lh, color, tipText(l))
+		);
+		usedR0.set(l.source, usedR0.get(l.source) + lh);
+		usedL1.set(l.target, usedL1.get(l.target) + lh);
+	}
+	for (const l of linksMD) {
+		const src = map1.get(l.source);
+		const tgt = map2.get(l.target);
+		if (!src || !tgt) continue;
+		const lh = Math.min(
+			linkPx(l.value, flow1down.get(l.source) || l.value, src.h),
+			linkPx(l.value, flow2.get(l.target) || l.value, tgt.h)
+		);
+		const color = getLinkColor(l._origin || l);
+		paths.push(
+			bezierPath(src, usedR1.get(l.source), tgt, usedL2.get(l.target), lh, color, tipText(l))
+		);
+		usedR1.set(l.source, usedR1.get(l.source) + lh);
+		usedL2.set(l.target, usedL2.get(l.target) + lh);
+	}
+
+	return { nodes0, nodes1, nodes2, paths };
+}
+
+function truncate(str, max = 13) {
+	if (!str) return "";
+	return str.length > max ? str.slice(0, max) + "…" : str;
+}
+
+function tableHeaderSource(layerRaw) {
+	const cols = sankeyColumns.value;
+	if (!cols.length) return "Source";
+	const idx = allLayerValues.value.indexOf(layerRaw);
+	return cols[idx] || "Source";
+}
+
+function tableHeaderTarget(layerRaw) {
+	const cols = sankeyColumns.value;
+	if (!cols.length) return "Target";
+	const idx = allLayerValues.value.indexOf(layerRaw);
+	return cols[idx + 1] || "Target";
+}
+
+function nodeColor() {
+	return "#6b8fa3";
+}
+</script>
+
+<template>
+  <div v-if="activeChart === 'SankeyChart'" class="sankey-wrapper">
+    <!-- Table view (MoreInfo dialog) -->
+    <template v-if="mode === 'large'">
+      <div class="table-controls">
+        <button
+          v-for="lv in allLayerValues"
+          :key="lv"
+          :class="['layer-btn', { 'layer-btn-active': tableLayer === lv }]"
+          @click="tableLayer = lv"
+        >{{ layerLabel(lv) }}</button>
+        <select
+          v-for="f in filterFields"
+          :key="`tbl-${f.field}`"
+          v-model="filterValues[f.field]"
+          class="sankey-select"
+        >
+          <option
+            v-for="opt in filterOptionsByField[f.field] || []"
+            :key="opt"
+            :value="opt"
+          >{{ opt === '全部' ? `${f.label || f.field}：全部` : opt }}</option>
+        </select>
+      </div>
+      <div class="supply-table-wrap">
+        <table class="supply-table">
+          <thead>
+            <tr>
+              <th>{{ tableHeaderSource(tableLayer) }}</th>
+              <th>{{ tableHeaderTarget(tableLayer) }}</th>
+              <th>數值{{ unit ? `（${unit}）` : '' }}</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="(row, i) in tableRows" :key="i">
+              <td>{{ row.source }}</td>
+              <td>{{ row.target }}</td>
+              <td class="count-cell">{{ (row.value || 0).toLocaleString() }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </template>
+
+    <!-- Chart view (normal) -->
+    <template v-else>
+      <div class="sankey-controls">
+        <div v-if="allLayerValues.length > 1" class="layer-btn-group">
+          <button
+            :class="['layer-btn', { 'layer-btn-active': selectedLayer === '全部' }]"
+            @click="selectedLayer = '全部'"
+          >全部</button>
+          <button
+            v-for="lv in allLayerValues"
+            :key="lv"
+            :class="['layer-btn', { 'layer-btn-active': selectedLayer === lv }]"
+            @click="selectedLayer = lv"
+          >{{ layerLabel(lv) }}</button>
+        </div>
+        <div class="sankey-selects">
+          <select
+            v-for="f in filterFields"
+            :key="f.field"
+            v-model="filterValues[f.field]"
+            class="sankey-select"
+          >
+            <option
+              v-for="opt in filterOptionsByField[f.field] || []"
+              :key="opt"
+              :value="opt"
+            >{{ opt === '全部' ? `${f.label || f.field}：全部` : opt }}</option>
+          </select>
+        </div>
+      </div>
+
+      <div v-if="hoveredTooltip" class="sankey-tooltip">{{ hoveredTooltip }}</div>
+
+      <div ref="containerRef" class="sankey-scroll">
+        <svg
+          :width="svgWidth"
+          :height="svgHeight"
+          :viewBox="`0 0 ${svgWidth} ${svgHeight}`"
+          class="sankey-svg"
+        >
+          <text
+            v-if="sankeyColumns[0] && layout.nodes0.length"
+            :x="X[0] + NODE_W / 2"
+            :y="PAD_TOP - 14"
+            class="layer-label"
+          >{{ sankeyColumns[0] }}</text>
+          <text
+            v-if="sankeyColumns[1] && layout.nodes1.length"
+            :x="X[1] + NODE_W / 2"
+            :y="PAD_TOP - 14"
+            class="layer-label"
+          >{{ sankeyColumns[1] }}</text>
+          <text
+            v-if="sankeyColumns[2] && layout.nodes2.length"
+            :x="X[2] + NODE_W / 2"
+            :y="PAD_TOP - 14"
+            class="layer-label"
+          >{{ sankeyColumns[2] }}</text>
+
+          <path
+            v-for="(p, i) in layout.paths"
+            :key="`p-${i}`"
+            :d="p.d"
+            :fill="p.fill"
+            class="sankey-link"
+            @mouseenter="hoveredTooltip = p.tip"
+            @mouseleave="hoveredTooltip = null"
+          />
+
+          <g v-for="n in layout.nodes0" :key="`n0-${n.name}`">
+            <rect :x="n.x" :y="n.y" :width="NODE_W" :height="n.h" :fill="nodeColor()" class="sankey-node" />
+            <text :x="n.x - 5" :y="n.y + n.h / 2" text-anchor="end" dominant-baseline="middle" class="node-label">{{ truncate(n.name) }}</text>
+          </g>
+          <g v-for="n in layout.nodes1" :key="`n1-${n.name}`">
+            <rect :x="n.x" :y="n.y" :width="NODE_W" :height="n.h" :fill="nodeColor()" class="sankey-node" />
+            <text :x="n.x + NODE_W + 5" :y="n.y + n.h / 2" text-anchor="start" dominant-baseline="middle" class="node-label">{{ truncate(n.name) }}</text>
+          </g>
+          <g v-for="n in layout.nodes2" :key="`n2-${n.name}`">
+            <rect :x="n.x" :y="n.y" :width="NODE_W" :height="n.h" :fill="nodeColor()" class="sankey-node" />
+            <text :x="n.x + NODE_W + 5" :y="n.y + n.h / 2" text-anchor="start" dominant-baseline="middle" class="node-label">{{ truncate(n.name, 16) }}</text>
+          </g>
+        </svg>
+      </div>
+
+      <div v-if="colorMap && colorMap.size" class="sankey-legend">
+        <span v-for="[val, color] in colorMap" :key="val">
+          <i :style="`background:${color}`" />{{ val }}
+        </span>
+      </div>
+    </template>
+  </div>
+</template>
+
+<style scoped lang="scss">
+.sankey-wrapper {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  background: transparent;
+  overflow: visible;
+}
+
+.sankey-controls,
+.table-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0 0.5rem;
+  flex-shrink: 0;
+  flex-wrap: wrap;
+}
+
+.layer-btn-group { display: flex; gap: 2px; }
+
+.layer-btn {
+  font-size: 0.72rem;
+  padding: 2px 10px;
+  border-radius: 4px;
+  border: 1px solid var(--color-border, #555);
+  background: var(--color-component-background, #1e1e1e);
+  color: var(--color-text-secondary, #aaa);
+  cursor: pointer;
+  font-weight: 500;
+  transition: background 0.15s, color 0.15s;
+  white-space: nowrap;
+
+  &-active {
+    background-color: var(--color-complement-text, #5b8db8);
+    color: white;
+    border-color: transparent;
+  }
+}
+
+.sankey-selects { margin-left: auto; display: flex; gap: 6px; flex-wrap: wrap; }
+
+.sankey-select {
+  background-color: var(--color-component-background, #1e1e1e);
+  color: var(--color-text, #eee);
+  border: 1px solid var(--color-border, #555);
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-size: 0.72rem;
+  cursor: pointer;
+  &:focus { outline: none; }
+}
+
+.sankey-scroll {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+
+  &::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+  }
+  &::-webkit-scrollbar-thumb {
+    background: var(--color-border, #555);
+    border-radius: 4px;
+  }
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+}
+
+.sankey-svg {
+  display: block;
+}
+
+.sankey-link {
+  opacity: 0.45;
+  transition: opacity 0.15s;
+  cursor: pointer;
+  &:hover { opacity: 0.8; }
+}
+
+.sankey-node { rx: 2; }
+
+.layer-label {
+  fill: var(--color-text-secondary, #aaa);
+  font-size: 13px;
+  text-anchor: middle;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+}
+
+.node-label {
+  fill: var(--color-text, #ddd);
+  font-size: 11px;
+  pointer-events: none;
+}
+
+.sankey-tooltip {
+  position: absolute;
+  top: 3.2rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(0, 0, 0, 0.85);
+  color: #fff;
+  padding: 4px 12px;
+  border-radius: 4px;
+  font-size: 0.78rem;
+  pointer-events: none;
+  white-space: nowrap;
+  z-index: 10;
+}
+
+.sankey-legend {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  font-size: 0.72rem;
+  color: var(--color-text-secondary, #aaa);
+  flex-shrink: 0;
+  flex-wrap: wrap;
+
+  span { display: flex; align-items: center; gap: 4px; }
+  i { display: inline-block; width: 10px; height: 10px; border-radius: 2px; }
+}
+
+.supply-table-wrap {
+  flex: 1;
+  overflow-x: auto;
+  overflow-y: auto;
+  padding: 0 0.5rem;
+  min-height: 0;
+}
+
+.supply-table {
+  min-width: 100%;
+  border-collapse: collapse;
+  font-size: 0.78rem;
+
+  th {
+    position: sticky;
+    top: 0;
+    background: var(--color-component-background, #1e1e1e);
+    color: var(--color-text-secondary, #aaa);
+    font-weight: 600;
+    padding: 6px 10px;
+    text-align: left;
+    border-bottom: 1px solid var(--color-border, #444);
+    white-space: nowrap;
+  }
+
+  td {
+    padding: 5px 10px;
+    border-bottom: 1px solid rgba(255,255,255,0.05);
+    color: var(--color-text, #ddd);
+    vertical-align: middle;
+    white-space: nowrap;
+  }
+
+  tr:hover td { background: rgba(255,255,255,0.04); }
+
+  .count-cell {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+    color: var(--color-complement-text, #5b8db8);
+  }
+}
+</style>

--- a/Taipei-City-Dashboard-FE/src/dashboardComponent/utilities/chartTypes.ts
+++ b/Taipei-City-Dashboard-FE/src/dashboardComponent/utilities/chartTypes.ts
@@ -23,4 +23,5 @@ export const chartTypes: chartType = {
 	IndicatorChart: "指標圖", // V
 	MapLegend: "地圖圖例", // V
 	TextUnitChart: "文字數值圖", // V
+	SankeyChart: "桑基圖", // V
 };


### PR DESCRIPTION
## 一、功能名稱

新增桑基圖（SankeyChart）作為 Taipei City Dashboard 通用圖表類型，支援多層級流向視覺化。對應雙北程式設計節「古鍾趙黃林」隊整併項目之「功能整併」。

## 二、相關程式異動清冊

### 前端 (`Taipei-City-Dashboard-FE/`)

| 路徑 | 異動類型 |
|------|---------|
| `src/dashboardComponent/components/SankeyChart.vue` | 新增 |
| `src/dashboardComponent/utilities/chartTypes.ts` | 修改（+1 行）|
| `src/dashboardComponent/DashboardComponent.vue` | 修改 |

### 後端 / 資料端

**無異動**。本 PR 純前端圖型新增；對應的 DAG / 組件設定 / 範例資料屬團隊整併分支 PR（`feature/team-no3-guzhong-team`）範圍。

### 各檔案用途說明

**`src/dashboardComponent/components/SankeyChart.vue`（新增）**

桑基圖元件本體。純 SVG 渲染（ApexCharts 不支援桑基圖，符合官方 `custom-charts.md` 對「不依賴第三方 library 的自訂圖表」路線）。

對外契約遵循其他圖表慣例：

- Props（7 個）：`chart_config`、`activeChart`、`series`、`map_config`、`map_filter`、`map_filter_on`、`mode`
- Emits（5 個）：`filterByParam`、`filterByLayer`、`clearByParamFilter`、`clearByLayerFilter`、`fly`

> 註：本元件目前不主動發出 emit 事件（不接地圖過濾），但仍宣告完整事件契約以對齊既有圖型介面，便於未來擴充。

**`src/dashboardComponent/utilities/chartTypes.ts`（修改）**

註冊新圖表類型：

```ts
SankeyChart: "桑基圖",
```

**`src/dashboardComponent/DashboardComponent.vue`（修改）**

整合桑基圖到 DashboardComponent 容器：

- 新增 SankeyChart 的 import
- `returnChartComponent` switch 加入對應 case
- 新增 `isWide` 計算屬性與 `.wide` CSS 類，讓桑基圖在 `default` 模式吃滿 3 欄 grid。觸發條件：`chart_config.types.includes("SankeyChart") && mode === "default"`，其他圖型不受影響
- 子組件多傳一個 `:mode="mode"` prop（其他圖型透明忽略，無副作用）

## 三、設計取捨

### 1. 對外資料介面（`chart_config` 擴充）

桑基圖資料天然多維（節點、流向、層級、metadata），不直接吻合官方既有 5 種 data type（`two_d` / `three_d` / `time` / `percent` / `map_legend`）。

本 PR **不新增官方資料類型**，而是擴用 `two_d` 攜帶 Sankey-shape：每筆 link 必要欄位為 `source` / `target` / `value` / `layer`，其餘 metadata 可任意攜帶。具體格式請見「**附錄一：完整介面範例**」。

Sankey 元件透過 `chart_config` 取得渲染與互動行為，所有領域語意全部由組件設定驅動，圖型本身保持中性。

#### Sankey 專屬 `chart_config` 欄位（皆可選）

| 欄位 | 型別 | 用途 |
|------|------|------|
| `sankey_columns` | `string[]`（最多 3 個） | 三欄上方標題；未提供則不顯示。詳見附錄二 |
| `sankey_filters` | `[{field, label}]` | 動態下拉，依資料 unique value 自動產生 |
| `sankey_layer_labels` | `{raw: pretty}` | 美化 layer toggle 文字（key 對應 link.layer 的 raw 值）|
| `sankey_color_by` | `string` | 用哪個欄位決定流向顏色 |
| `sankey_color_map` | `{value: color}` | 顯式色票覆寫（依該欄位的 value）|
| `sankey_max_nodes` | `number` | 每欄獨立上限，預設 25 |

#### 既有 `chart_config` 慣例沿用

| 欄位 | 型別 | 用途 |
|------|------|------|
| `color` | `string[]` | fallback 色票，索引依 unique value 首次出現順序 |
| `unit` | `string` | tooltip 數值與表格欄位的後綴 |

`sankey_*` 前綴為 namespace，避免跟未來其他圖型新增欄位衝突。

### 2. 內建 filter UI

桑基圖通常獨立呈現（非地圖驅動），且資料多維天然需要互動篩選。本元件自帶資料驅動的 filter UI（layer toggle + dropdown），不依賴 `map_filter`。

### 3. ResizeObserver 響應寬度

ApexCharts 自帶容器追蹤，純 SVG 沒有；若用 `preserveAspectRatio="meet"` 縮放會使文字過小。本元件以 `ResizeObserver` 追蹤外層寬度，動態計算 `svgWidth` 與三欄 X 座標：

- 最小寬度 `1000px`：低於此寬度時水平 scroll bar 出現
- 大螢幕：SVG 隨容器寬擴張，X 座標依 `[0.121, 0.4375, 0.863]` 比例分配三欄
- 配合 `overflow: auto` 滾動容器，兼顧大螢幕填滿與窄螢幕仍可閱讀

### 4. 級聯過濾（cascade filter）

2 層 Sankey 鏈式特性下，當篩選欄位只存在於其中一層時（例如 `district` 僅在下游 link），元件自動級聯：

1. 該欄位對「沒有此欄位的 link」靜默通過（不過濾掉）
2. 篩選後，未被直接過濾的一層回頭縮為「target / source 連接到對側存活節點」的 link

此邏輯內建於通用 chart 程式，不需組件設定特別宣告，因為它是 Sankey 圖型語意而非領域語意。

### 5. AI 功能不包含

團隊原本桑基圖整合的 AI 解讀功能，依官方信件「AI 功能先不納入本次整併指定內容」明確排除，已於本 PR 完全剝離。

## 四、測試方式與驗收重點

### 開發環境執行

```bash
cd Taipei-City-Dashboard-FE
npm install
npm run dev
```

### 驗收路徑

在任一 dashboard 將組件 `chart_config.types` 設為 `["SankeyChart"]`，並提供符合「附錄一」格式的 `chart_data`。完整可執行範例見附錄一。

### 驗收重點

- [ ] 桑基圖正常渲染（節點 + 流向 + tooltip）
- [ ] `chart_config.sankey_columns` 有提供時三欄上方顯示標題；未提供時乾淨無文字
- [ ] `chart_config.sankey_filters` 動態生成下拉，下拉選項由資料 unique value 推導
- [ ] Layer toggle 由 `link.layer` unique values 動態產生，只有單一 layer 時自動隱藏 toggle
- [ ] 篩選只存在於某層的欄位時，另一層自動級聯保留相關 link（不會整層消失）
- [ ] 視窗 resize 時 SVG 寬度動態跟隨
- [ ] 節點過多時 scroll bar 出現，可滾覽完整 Top-N 節點
- [ ] `.wide` layout 在 `default` 模式吃 3 欄寬，其他圖型 layout 不受影響（同頁面其他卡片排版不變）
- [ ] `mode === "large"`（透過 MoreInfo dialog 觸發）切換為表格視圖：顯示當前 layer 的 source / target / 數值欄位，依數值 desc 排序前 200 筆

### 已知限制

- **Layer 數量**：假設資料最多 2 個 `layer` unique 值（形成 col0 → col1 → col2 三欄鏈式）。多於 2 層時，依出現順序前 2 個會被採用，其他 layer 的 link 不渲染（不報錯）。
- **節點上限**：預設 `sankey_max_nodes = 25` 為效能保守值。Sankey 邊複雜度為 O(n²)（每欄 n 個節點，最壞 n² 條邊），50 節點約 2500 條邊微頓、100 節點約 10000 條邊明顯卡。組件可依資料量與效能需求透過 `chart_config.sankey_max_nodes` 調整。
- **資料量**：超過上限的節點依該欄 flow 總和 desc 排序，取前 N 名；未入榜節點及其關聯 link 不渲染。

## 五、相依

本 PR 從 `feature/award-dag-integration` 開出，與「組件整併」分支 `feature/team-no3-guzhong-team` 平行進行；該分支會提供實際使用此圖表的「雙北學校供餐供應鏈」組件設定、DAG 與範例資料。

## 六、commit 結構說明

本分支包含兩個 commit：

1. `chore: 將 .claude/ 加入 gitignore` — 與功能無直接相依，避免 AI 代理本地狀態被誤 commit。如官方認為應拆出獨立 PR 或不採用，可自行 rebase 移除。
2. `feat(FE): 新增桑基圖（SankeyChart）通用圖表類型` — 本 PR 主要功能內容。

## 七、附錄

### 附錄一：完整介面範例

以「雙北學校供餐供應鏈」為例（屬組件整併 PR 範圍，此處僅作介面示範）：

```js
// component.chart_config
{
  types: ["SankeyChart"],
  unit: "次",
  color: ["#5b9fe8", "#f59e0b"],
  sankey_columns: ["原料供應商", "供餐業者", "學校"],
  sankey_filters: [
    { field: "city", label: "縣市" },
    { field: "district", label: "區域" }
  ],
  sankey_layer_labels: { "up-mid": "上游", "mid-down": "下游" },
  sankey_color_by: "city",
  sankey_color_map: { "臺北市": "#5b9fe8", "新北市": "#f59e0b" },
  sankey_max_nodes: 25
}

// component.chart_data
[
  {
    name: "links",
    data: [
      {
        source: "新祥紀食品有限公司",
        target: "第一餐盒股份有限公司",
        value: 887,
        layer: "up-mid",
        city: "臺北市"
      },
      {
        source: "第一餐盒股份有限公司",
        target: "大安國小",
        value: 320,
        layer: "mid-down",
        city: "臺北市",
        district: "大安區"
      }
      // ... 更多 link
    ]
  }
]
```

### 附錄二：參數規則補充

**資料層**

- `series` 結構：採 `two_d` 形式包裝，外層陣列固定 1 個物件 `{ name, data: [link, ...] }`。`name` 是描述性字串，元件不依賴其值。
- `link` 必要欄位：`source: string`、`target: string`、`value: number > 0`、`layer: string`。缺任何必要欄位或 `value ≤ 0` 的 link 不渲染（不報錯）。
- `link` 額外欄位：任何欄位（如 `city` / `district` / `category`）可作為 `sankey_filters` / `sankey_color_by` 引用對象。
- `layer` 排序：元件依 link 陣列中**首次出現順序**決定欄位位置。第一個 `layer` 值放 col0 → col1（左半），第二個放 col1 → col2（右半）。

**欄位規則**

- `sankey_columns`：陣列長度對應顯示欄數。
  - 3 個：顯示 col0、col1、col2 三欄標題
  - 2 個：只顯示 col0、col1
  - 1 個：只顯示 col0
  - 0 個 / 未提供：完全不顯示標題

- `sankey_filters`：`field` 可為 link 上任一額外欄位。元件對「沒有該欄位」的 link 靜默通過（見「設計取捨 4. 級聯過濾」）。

- `sankey_layer_labels`：key 對應 `link.layer` 原始值，value 為顯示用文字。未提供 mapping 的 layer 顯示原始值。

- `sankey_color_by` + `sankey_color_map` + `color`：顏色決定優先順序如下，由高到低：
  1. `sankey_color_map[link[sankey_color_by]]`（顯式色票）
  2. `chart_config.color[i]`（i 為該值在資料中**首次出現的順序**）
  3. 元件內建 `DEFAULT_PALETTE`（6 色循環）
  4. `#888888`（最終 fallback）

- `sankey_max_nodes`：每欄獨立上限。三欄各自依 flow 總和 desc 取前 N 名節點，未入榜節點及相關 link 不渲染。

**互動行為**

- Layer toggle：自動依 `link.layer` unique values 動態生成 buttons。
  - 只有 1 個 layer 值：toggle 隱藏（無切換必要）
  - 2 個 layer 值：顯示「全部 / layerA / layerB」三按鈕

- MoreInfo dialog：在 DashboardComponent 點 `組件資訊` / `MoreInfo` 按鈕後，元件以 `mode === "large"` 重新渲染為表格視圖。表格欄位：
  - 第 1 欄：`sankey_columns[layerIdx]`（或 `Source`）
  - 第 2 欄：`sankey_columns[layerIdx + 1]`（或 `Target`）
  - 第 3 欄：數值（含 `unit` 後綴）

**Edge cases**

| 情境 | 行為 |
|------|------|
| `chart_data` 為空陣列 | 渲染空 SVG（無報錯） |
| 所有 link 的 `value` 都 ≤ 0 | 渲染空 SVG（無報錯） |
| `chart_config` 完全未提供 sankey_* 任何欄位 | 中性樣貌：無欄頭、無 filter、灰色流向、layer toggle 顯示原始值 |
| 資料含 3+ 個 layer 值 | 取出現順序前 2 個，其他 layer 的 link 不渲染 |
| `sankey_color_by` 指定的欄位某 link 沒有 | 該 link 套用最終 fallback `#888888` |
