### PR TITLE
Fix Airflow production ETL alerts

### DIFF
--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D090100_1/D090100_1.py
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D090100_1/D090100_1.py
@@ -5,7 +5,10 @@ from operators.common_pipeline import CommonDag
 def _D090100_1(**kwargs):
     import pandas as pd
     from sqlalchemy import create_engine
-    from utils.extract_stage import get_data_taipei_file_last_modified_time
+    from utils.extract_stage import (
+        get_data_taipei_file_last_modified_time,
+        read_csv_with_encoding_fallback,
+    )
     from utils.load_stage import (
         save_geodataframe_to_postgresql,
         update_lasttime_in_data_to_dataset_info,
@@ -27,13 +30,13 @@ def _D090100_1(**kwargs):
     default_table = dag_infos.get("ready_data_default_table")
     history_table = dag_infos.get("ready_data_history_table")
     URL = "https://data.taipei/api/frontstage/tpeod/dataset/resource.download?rid=28c5792b-3af6-4bff-8ad8-f5b5e53d4062"
-    ENCODING = "big5"
+    ENCODINGS = ("utf-8-sig", "utf-8", "cp950", "big5")
     PAGE_ID = "58b4f7b9-d0c5-4de8-aa7f-981fcb625e45"
     FROM_CRS = 4326
     GEOMETRY_TYPE = "Point"
 
     # Extract
-    raw_data = pd.read_csv(URL, encoding=ENCODING)
+    raw_data = read_csv_with_encoding_fallback(URL, encodings=ENCODINGS)
     raw_data = raw_data.loc[
         raw_data["school"].notnull(), ~raw_data.columns.str.startswith("Unnamed")
     ]

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D100103/D100103.py
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/D100103/D100103.py
@@ -28,6 +28,30 @@ def D100103(**kwargs):
     # Clean up year column
     data['year'] = data['統計期'].str.replace(r'[^\d]', '', regex=True)
     data["year"] = data["year"].apply(lambda x: int(x) + 1911)
+
+    count_columns = {
+        "總計": [
+            "就業保險育嬰留職停薪津貼初次核付人數[人]/ 總計",
+            "就業保險育嬰留職停薪津貼初次核付件數[件]/ 總計",
+        ],
+        "男": [
+            "就業保險育嬰留職停薪津貼初次核付人數[人]/ 男",
+            "就業保險育嬰留職停薪津貼初次核付件數[件]/ 男",
+        ],
+        "女": [
+            "就業保險育嬰留職停薪津貼初次核付人數[人]/ 女",
+            "就業保險育嬰留職停薪津貼初次核付件數[件]/ 女",
+        ],
+    }
+    count_columns = {
+        category: next((col for col in candidates if col in data.columns), None)
+        for category, candidates in count_columns.items()
+    }
+    missing_categories = [
+        category for category, col in count_columns.items() if col is None
+    ]
+    if missing_categories:
+        raise KeyError(f"Missing parental leave count columns: {missing_categories}")
     
     # Reshape from wide to long format
     # Create records for each gender category
@@ -35,34 +59,23 @@ def D100103(**kwargs):
     
     for _, row in data.iterrows():
         year = row['year']
-        
-        # Total
-        records.append({
-            'year': year,
-            'category': '總計',
-            'parental_leave_count': row['就業保險育嬰留職停薪津貼初次核付人數[人]/ 總計']
-        })
-        
-        # Male
-        records.append({
-            'year': year,
-            'category': '男',
-            'parental_leave_count': row['就業保險育嬰留職停薪津貼初次核付人數[人]/ 男']
-        })
-        
-        # Female
-        records.append({
-            'year': year,
-            'category': '女',
-            'parental_leave_count': row['就業保險育嬰留職停薪津貼初次核付人數[人]/ 女']
-        })
+        for category, source_col in count_columns.items():
+            records.append({
+                'year': year,
+                'category': category,
+                'parental_leave_count': row[source_col]
+            })
     
     # Create new dataframe from records
     data = pd.DataFrame(records)
     
     # Convert data types
     data["year"] = data["year"].astype(int)
-    data["parental_leave_count"] = data["parental_leave_count"].astype(int)
+    data["parental_leave_count"] = (
+        pd.to_numeric(data["parental_leave_count"], errors="coerce")
+        .fillna(0)
+        .astype(int)
+    )
     # Time
     data["data_time"] = get_tpe_now_time_str(is_with_tz=True)
     # Reshape

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0033_1/R0033_1.py
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0033_1/R0033_1.py
@@ -5,6 +5,7 @@ from operators.common_pipeline import CommonDag
 def _R0033_1(**kwargs):
     import pandas as pd
     from sqlalchemy import create_engine
+    from utils.extract_stage import read_csv_with_encoding_fallback
     from utils.load_stage import (
         save_geodataframe_to_postgresql,
         update_lasttime_in_data_to_dataset_info,
@@ -20,12 +21,12 @@ def _R0033_1(**kwargs):
     default_table = dag_infos.get("ready_data_default_table")
     history_table = dag_infos.get("ready_data_history_table")
     URL = "https://data.taipei/api/frontstage/tpeod/dataset/resource.download?rid=4486e759-4159-4208-9832-c32300c4e832"
-    ENCODING = "cp950"
+    ENCODINGS = ("utf-8-sig", "utf-8", "cp950", "big5")
     FROM_CRS = 3826
-    GEOMETRY_TYPE = "Polygon"
+    GEOMETRY_TYPE = "Point"
 
     # Extract
-    raw_data = pd.read_csv(URL, encoding=ENCODING)
+    raw_data = read_csv_with_encoding_fallback(URL, encodings=ENCODINGS)
 
     # Transform
     data = raw_data.copy()

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0034/R0034.py
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0034/R0034.py
@@ -6,7 +6,6 @@ def _R0034(**kwargs):
     import geopandas as gpd
     import pandas as pd
     import requests
-    from airflow.models import Variable
     from sqlalchemy import create_engine
     from utils.load_stage import (
         save_geodataframe_to_postgresql,
@@ -24,9 +23,7 @@ def _R0034(**kwargs):
     load_behavior = dag_infos.get("load_behavior")
     default_table = dag_infos.get("ready_data_default_table")
     history_table = dag_infos.get("ready_data_history_table")
-    login_id = Variable.get("HEO_ID")
-    data_key = Variable.get("HEO_APIKEY")
-    URL = f"https://wic.heo.taipei/OpenData/API/Sewer/Get?stationNo=&loginId={login_id}&dataKey={data_key}"
+    URL = "https://wic.gov.taipei/OpenData/API/Sewer/Get?stationNo=&loginId=sewer01&dataKey=BD3E513A"
     FROM_CRS = 4326
     GEOMETRY_TYPE = "Point"
 

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0042/R0042.py
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0042/R0042.py
@@ -6,6 +6,7 @@ def _R0042(**kwargs):
     import pandas as pd
     import requests
     from sqlalchemy import create_engine
+    from utils.extract_stage import read_csv_with_encoding_fallback
     from utils.load_stage import (
         save_geodataframe_to_postgresql,
         update_lasttime_in_data_to_dataset_info,
@@ -40,10 +41,10 @@ def _R0042(**kwargs):
         last_modified = item["last_modified"]
         file_name = item["file_name"]
         # read csv
-        try:
-            temp = pd.read_csv(URL, encoding=encoding)
-        except UnicodeDecodeError:
-            temp = pd.read_csv(URL, encoding="cp950")
+        temp = read_csv_with_encoding_fallback(
+            URL,
+            encodings=(encoding, "utf-8-sig", "utf-8", "cp950", "big5"),
+        )
         temp["file_name"] = file_name
         temp["data_time"] = last_modified
         temps.append(temp)

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0069/R0069.py
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0069/R0069.py
@@ -5,6 +5,10 @@ from operators.common_pipeline import CommonDag
 def _R0069(**kwargs):
     import pandas as pd
     from sqlalchemy import create_engine
+    from utils.extract_stage import (
+        get_current_rid_from_page_id,
+        read_csv_with_encoding_fallback,
+    )
     from utils.load_stage import (
         save_geodataframe_to_postgresql,
         update_lasttime_in_data_to_dataset_info,
@@ -25,21 +29,32 @@ def _R0069(**kwargs):
     load_behavior = dag_infos.get("load_behavior")
     default_table = dag_infos.get("ready_data_default_table")
     history_table = dag_infos.get("ready_data_history_table")
-    #URL = "https://data.taipei/api/frontstage/tpeod/dataset/resource.download?rid=797999ac-a4b8-4ffe-abfd-019c95122350"
-    URL = "https://data.taipei/dataset/detail?id=feaa5be3-0c43-4f0b-a46f-8a57cfd75d7a"
-    ENCODING = "cp950"
+    PAGE_ID = "feaa5be3-0c43-4f0b-a46f-8a57cfd75d7a"
+    rid = get_current_rid_from_page_id(PAGE_ID)
+    URL = f"https://data.taipei/api/frontstage/tpeod/dataset/resource.download?rid={rid}"
+    ENCODINGS = ("utf-8-sig", "utf-8", "cp950", "big5")
     FROM_CRS = 4326
-    GEOMETRY_TYPE = "Polygon"
+    GEOMETRY_TYPE = "Point"
 
     # Extract
-    raw_data = pd.read_csv(URL, encoding=ENCODING)
+    raw_data = read_csv_with_encoding_fallback(URL, encodings=ENCODINGS)
 
     # Transform
     data = raw_data.copy()
+    data = data.rename(
+        columns={
+            "序號": "編號",
+            "AREA_平方公尺": "閒置面積_㎡",
+        }
+    )
     # geocoding
-    addr_cleaned = clean_data(data["門牌"])
+    if "行政區" in data.columns:
+        addr = "臺北市" + data["行政區"].fillna("") + data["門牌"].fillna("")
+    else:
+        addr = data["門牌"]
+    addr_cleaned = clean_data(addr)
     standard_addr_list = main_process(addr_cleaned)
-    result, output = save_data(data["門牌"], addr_cleaned, standard_addr_list)
+    result, output = save_data(addr, addr_cleaned, standard_addr_list)
     data["門牌"] = output
     x, y = get_addr_xy_parallel(output)
     # geometry

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0075/R0075.py
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/R0075/R0075.py
@@ -5,6 +5,7 @@ from operators.common_pipeline import CommonDag
 def _R0075(**kwargs):
     import pandas as pd
     from sqlalchemy import create_engine
+    from utils.extract_stage import read_csv_with_encoding_fallback
     from utils.load_stage import (
         save_geodataframe_to_postgresql,
         update_lasttime_in_data_to_dataset_info,
@@ -20,17 +21,17 @@ def _R0075(**kwargs):
     default_table = dag_infos.get("ready_data_default_table")
     history_table = dag_infos.get("ready_data_history_table")
     URL = "https://data.taipei/api/frontstage/tpeod/dataset/resource.download?rid=b9f8154d-c627-48a8-b3ef-512ed9cde9e7"
-    ENCODING = "big5"
+    ENCODINGS = ("utf-8-sig", "utf-8", "cp950", "big5")
     FROM_CRS = 4326
     GEOMETRY_TYPE = "Point"
 
     # Extract
-    raw_data = pd.read_csv(URL, encoding=ENCODING)
+    raw_data = read_csv_with_encoding_fallback(URL, encodings=ENCODINGS)
     is_no_header = raw_data.columns[0] != "序號"
     if is_no_header:
-        raw_data = pd.read_csv(
+        raw_data = read_csv_with_encoding_fallback(
             URL,
-            encoding=ENCODING,
+            encodings=ENCODINGS,
             header=None,
             names=[
                 "序號",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/population_age_distribution_monthly/population_age_distribution_monthly.py
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/population_age_distribution_monthly/population_age_distribution_monthly.py
@@ -47,7 +47,9 @@ def _transfer(**kwargs):
             "老年人口數[65歲以上][人]": "elderly_population",  # 65歲以上人口數
             "老年人口占全市人口比率[%]": "elderly_population_percentage",  # 65歲以上占全市人口比率
             "扶養比[%]": "total_dependency_ratio",  # 扶養比（％）
+            "扶養比": "total_dependency_ratio",
             "老化指數[%]": "aging_index",  # 老化指數（％）
+            "老化指數": "aging_index",
         }
     )
     data["data_time"] = get_tpe_now_time_str(is_with_tz=True)

--- a/Taipei-City-Dashboard-DE/dags/proj_new_taipei_city_dashboard/fire_narrow_street/fire_narrow_street.py
+++ b/Taipei-City-Dashboard-DE/dags/proj_new_taipei_city_dashboard/fire_narrow_street/fire_narrow_street.py
@@ -61,16 +61,24 @@ def _transfer(**kwargs):
     data = pd.DataFrame(res)
 
     col_map = {
+        "number": "seqno",
         "fire branch": "fire_brigade",
         "location": "street",
+        "address": "street",
         "district": "town",
-        "the width and length": "width_meter"
+        "the width and length": "width_meter",
+        "width": "width_meter",
+        "length": "length_meter",
     }
     data = data.rename(columns=col_map)
 
     data['county'] = '新北市'
-    data['width_meter'] = data['width_meter'].str.extract(r'寬度約:([0-9.]+)')
-    data['width_meter'] = data['width_meter'].astype(float)    
+    data['width_meter'] = (
+        data['width_meter']
+        .astype(str)
+        .str.extract(r'([0-9.]+)', expand=False)
+    )
+    data['width_meter'] = pd.to_numeric(data['width_meter'], errors='coerce')
     data["data_time"] = get_tpe_now_time_str(is_with_tz=True)
     data['address'] = '新北市' + data['town'] + data['street'].fillna('') + '1號'
         # get geometry

--- a/Taipei-City-Dashboard-DE/dags/proj_new_taipei_city_dashboard/flu_hospitals_ntpe/flu_hospitals_ntpe.py
+++ b/Taipei-City-Dashboard-DE/dags/proj_new_taipei_city_dashboard/flu_hospitals_ntpe/flu_hospitals_ntpe.py
@@ -12,6 +12,12 @@ def _transfer(**kwargs):
         save_geodataframe_to_postgresql,
         update_lasttime_in_data_to_dataset_info,
     )
+    from utils.transform_address import (
+        clean_data,
+        get_addr_xy_parallel,
+        main_process,
+        save_data,
+    )
     from utils.transform_geometry import add_point_wkbgeometry_column_to_df
 
     # Config
@@ -29,14 +35,24 @@ def _transfer(**kwargs):
     df['data_time'] = pd.to_datetime("now").strftime("%Y-%m-%d %H:%M:%S")
 
 
-    area_candidates = df['address'].str.slice(3, 6)
-    df['district'] = area_candidates.apply(lambda x: x if x.endswith('區') else None)
+    df['district'] = df['address'].str.extract(r"([^市縣\s]{1,3}區)", expand=False)
 
 
     df = df.rename(columns={
+        "telephone number": "tel",
         "wgs84ax": "lon",
         "wgs84ay": "lat",
     })
+    if "tel" not in df.columns:
+        df["tel"] = None
+
+    if "lon" not in df.columns or "lat" not in df.columns:
+        addr_cleaned = clean_data(df["address"])
+        standard_addr_list = main_process(addr_cleaned)
+        result, output = save_data(df["address"], addr_cleaned, standard_addr_list)
+        df["address"] = output
+        df["lon"], df["lat"] = get_addr_xy_parallel(output)
+
     df["lon"] = pd.to_numeric(df["lon"], errors="coerce")
     df["lat"] = pd.to_numeric(df["lat"], errors="coerce")
     gdata = add_point_wkbgeometry_column_to_df(

--- a/Taipei-City-Dashboard-DE/dags/utils/extract_stage.py
+++ b/Taipei-City-Dashboard-DE/dags/utils/extract_stage.py
@@ -251,6 +251,46 @@ def get_current_rid_from_page_id(page_id, resource_name_contains=None, timeout=3
     return resources[0]["rid"]
 
 
+def read_csv_with_encoding_fallback(source, encodings=None, **kwargs):
+    """
+    Read CSV with a small set of common Taipei open-data encodings.
+
+    data.taipei resource metadata is not always updated when data owners
+    republish files. Try strict decoding first, then retry with replacement so
+    one bad byte does not break an otherwise usable CSV.
+    """
+    if encodings is None:
+        encodings = ("utf-8-sig", "utf-8", "cp950", "big5")
+
+    ordered_encodings = []
+    for encoding in encodings:
+        if encoding and encoding not in ordered_encodings:
+            ordered_encodings.append(encoding)
+
+    last_error = None
+    for encoding in ordered_encodings:
+        try:
+            if hasattr(source, "seek"):
+                source.seek(0)
+            return pd.read_csv(source, encoding=encoding, **kwargs)
+        except UnicodeDecodeError as err:
+            last_error = err
+
+    replace_kwargs = dict(kwargs)
+    replace_kwargs.setdefault("encoding_errors", "replace")
+    for encoding in ordered_encodings:
+        try:
+            if hasattr(source, "seek"):
+                source.seek(0)
+            return pd.read_csv(source, encoding=encoding, **replace_kwargs)
+        except UnicodeDecodeError as err:
+            last_error = err
+
+    if last_error is not None:
+        raise last_error
+    return pd.read_csv(source, **kwargs)
+
+
 def get_data_taipei_api(rid, timeout=60, output_format="json"):
     """
     Retrieve data from Data.taipei API by automatically traversing all data.

--- a/Taipei-City-Dashboard-DE/db_migrations/20260519_airflow_alert_fixes.sql
+++ b/Taipei-City-Dashboard-DE/db_migrations/20260519_airflow_alert_fixes.sql
@@ -1,0 +1,42 @@
+BEGIN;
+
+ALTER TABLE IF EXISTS public.urbn_landuse_master_plan
+    ALTER COLUMN area_code TYPE varchar(50),
+    ALTER COLUMN area_short_name TYPE varchar(50);
+
+ALTER TABLE IF EXISTS public.urbn_landuse_master_plan_history
+    ALTER COLUMN area_code TYPE varchar(50),
+    ALTER COLUMN area_short_name TYPE varchar(50);
+
+CREATE SEQUENCE IF NOT EXISTS public.patrol_bike_theft_ogc_fid_seq;
+
+CREATE TABLE IF NOT EXISTS public.patrol_bike_theft (
+    case_id varchar NULL,
+    type varchar NULL,
+    date varchar NULL,
+    time varchar NULL,
+    location varchar NULL,
+    address varchar NULL,
+    wkb_geometry public.geometry(Point, 4326) NULL,
+    begin_when timestamptz NULL,
+    epoch_time float8 NULL,
+    _ctime timestamptz DEFAULT CURRENT_TIMESTAMP NULL,
+    _mtime timestamptz DEFAULT CURRENT_TIMESTAMP NULL,
+    ogc_fid integer DEFAULT nextval('public.patrol_bike_theft_ogc_fid_seq'::regclass) NOT NULL
+);
+
+ALTER SEQUENCE public.patrol_bike_theft_ogc_fid_seq
+    OWNED BY public.patrol_bike_theft.ogc_fid;
+
+CREATE INDEX IF NOT EXISTS patrol_bike_theft_wkb_geometry_geom_idx
+    ON public.patrol_bike_theft USING gist (wkb_geometry);
+
+DROP TRIGGER IF EXISTS auto_patrol_bike_theft_mtime ON public.patrol_bike_theft;
+CREATE TRIGGER auto_patrol_bike_theft_mtime
+    BEFORE INSERT OR UPDATE ON public.patrol_bike_theft
+    FOR EACH ROW EXECUTE FUNCTION trigger_set_timestamp();
+
+ALTER TABLE IF EXISTS public.patrol_bike_theft OWNER TO airflow;
+ALTER SEQUENCE IF EXISTS public.patrol_bike_theft_ogc_fid_seq OWNER TO airflow;
+
+COMMIT;


### PR DESCRIPTION
## Summary

Fixes a batch of production Airflow ETL failures caused by upstream schema/encoding changes and missing database schema.

Changes include:
- Add a shared CSV encoding fallback helper for Taipei open-data CSVs.
- Update affected Taipei DAGs to tolerate UTF-8/Big5/cp950 republished files.
- Update R0034 to use the new `wic.gov.taipei` sewer API endpoint.
- Fix R0069 to resolve the current data.taipei resource id instead of reading the HTML detail page.
- Make D100103 and population age distribution DAGs compatible with renamed statistics columns.
- Make New Taipei flu hospital and fire narrow street DAGs compatible with current API fields.
- Add a DB migration script for `urbn_landuse_master_plan.area_code` and `patrol_bike_theft`.

## Production Notes

Already manually verified on production after DB fixes:
- `proj_city_dashboard_R0054` succeeded.
- `proj_city_dashboard_bike_theft` succeeded.

Other adjusted DAGs are code-ready but still need deployment/rerun verification.

## Validation

- `python3 -m py_compile` on changed DAG/helper Python files.
- `git diff --cached --check`.
- R0034 endpoint returned HTTP 200 with data during manual check.
