### PR TITLE
[bombs-king] 功能: 新增旭日圖 SunburstChart

### DIFF
--- a/SunburstChart.vue
+++ b/SunburstChart.vue
@@ -1,13 +1,15 @@
+<!-- Developed by Bombs King, Taipei Codefest 2026 -->
+
 <script setup>
 import { computed, onBeforeUnmount, onMounted, ref } from "vue";
 
 const props = defineProps([
-	"chart_config",
-	"activeChart",
-	"series",
-	"map_config",
-	"map_filter",
-	"map_filter_on",
+  "chart_config",
+  "activeChart",
+  "series",
+  "map_config",
+  "map_filter",
+  "map_filter_on",
 ]);
 
 const wrapRef = ref(null);
@@ -15,130 +17,134 @@ const chartWidth = ref(420);
 const chartHeight = ref(260);
 let resizeObserver = null;
 const hoverTip = ref({
-	show: false,
-	x: 0,
-	y: 0,
-	text: "",
-	placeLeft: false,
-	placeAbove: true,
+  show: false,
+  x: 0,
+  y: 0,
+  text: "",
+  placeLeft: false,
+  placeAbove: true,
 });
 const hoveredNode = ref("");
 
 function normalizeRows(raw) {
-	if (Array.isArray(raw)) return raw;
-	if (!raw || typeof raw !== "object") return [];
-	const wrapped = raw.data || raw.rows || raw.items || raw.series || raw.result || null;
-	return Array.isArray(wrapped) ? wrapped : [];
+  if (Array.isArray(raw)) return raw;
+  if (!raw || typeof raw !== "object") return [];
+  const wrapped =
+    raw.data || raw.rows || raw.items || raw.series || raw.result || null;
+  return Array.isArray(wrapped) ? wrapped : [];
 }
 
 function parseLinks(raw) {
-	const rows = Array.isArray(raw?.edges) ? raw.edges : normalizeRows(raw);
-	return rows
-		.map((it) => ({
-			source: String(it.source ?? it.from ?? it.x_axis ?? it.x ?? "").trim(),
-			target: String(it.target ?? it.to ?? it.y_axis ?? "").trim(),
-			value: Number(it.value ?? it.data ?? it.y ?? 0),
-			color: it.color ? String(it.color) : null,
-		}))
-		.filter((it) => it.source && it.target && Number.isFinite(it.value) && it.value > 0);
+  const rows = Array.isArray(raw?.edges) ? raw.edges : normalizeRows(raw);
+  return rows
+    .map((it) => ({
+      source: String(it.source ?? it.from ?? it.x_axis ?? it.x ?? "").trim(),
+      target: String(it.target ?? it.to ?? it.y_axis ?? "").trim(),
+      value: Number(it.value ?? it.data ?? it.y ?? 0),
+      color: it.color ? String(it.color) : null,
+    }))
+    .filter(
+      (it) =>
+        it.source && it.target && Number.isFinite(it.value) && it.value > 0,
+    );
 }
 
 function getPalette() {
-	const c = props.chart_config?.color;
-	if (Array.isArray(c) && c.length > 0) return c;
-	return ["#4EA3FF", "#F5A623", "#7C4DFF", "#56B96D", "#E170A6", "#AF4137"];
+  const c = props.chart_config?.color;
+  if (Array.isArray(c) && c.length > 0) return c;
+  return ["#4EA3FF", "#F5A623", "#7C4DFF", "#56B96D", "#E170A6", "#AF4137"];
 }
 
 function getSunburstBranchColors() {
-	const cfg = props.chart_config?.sunburst_branch_colors;
-	if (
-		Array.isArray(cfg) &&
-		cfg.length >= 2 &&
-		cfg.every((x) => typeof x === "string" && x.trim())
-	) {
-		return [cfg[0], cfg[1]];
-	}
-	// Default branch colors requested by design: blue + orange.
-	return ["#4EA3FF", "#F5A623"];
+  const cfg = props.chart_config?.sunburst_branch_colors;
+  if (
+    Array.isArray(cfg) &&
+    cfg.length >= 2 &&
+    cfg.every((x) => typeof x === "string" && x.trim())
+  ) {
+    return [cfg[0], cfg[1]];
+  }
+  // Default branch colors requested by design: blue + orange.
+  return ["#4EA3FF", "#F5A623"];
 }
 
 function hexToRgb(hex) {
-	const s = String(hex || "").replace("#", "");
-	if (s.length !== 6) return null;
-	const n = Number.parseInt(s, 16);
-	if (!Number.isFinite(n)) return null;
-	return { r: (n >> 16) & 255, g: (n >> 8) & 255, b: n & 255 };
+  const s = String(hex || "").replace("#", "");
+  if (s.length !== 6) return null;
+  const n = Number.parseInt(s, 16);
+  if (!Number.isFinite(n)) return null;
+  return { r: (n >> 16) & 255, g: (n >> 8) & 255, b: n & 255 };
 }
 
 function parseAnyColorToRgb(input) {
-	const s = String(input || "").trim();
-	if (!s) return null;
-	const hex = hexToRgb(s);
-	if (hex) return hex;
-	const m = s.match(/^rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/i);
-	if (m) {
-		const r = Number(m[1]);
-		const g = Number(m[2]);
-		const b = Number(m[3]);
-		if ([r, g, b].every((n) => n >= 0 && n <= 255)) return { r, g, b };
-	}
-	return null;
+  const s = String(input || "").trim();
+  if (!s) return null;
+  const hex = hexToRgb(s);
+  if (hex) return hex;
+  const m = s.match(/^rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/i);
+  if (m) {
+    const r = Number(m[1]);
+    const g = Number(m[2]);
+    const b = Number(m[3]);
+    if ([r, g, b].every((n) => n >= 0 && n <= 255)) return { r, g, b };
+  }
+  return null;
 }
 
 function rgbToHsl(r, g, b) {
-	const rn = r / 255;
-	const gn = g / 255;
-	const bn = b / 255;
-	const max = Math.max(rn, gn, bn);
-	const min = Math.min(rn, gn, bn);
-	const l = (max + min) / 2;
-	let h = 0;
-	let s = 0;
-	if (max !== min) {
-		const d = max - min;
-		s = l > 0.5 ? d / (2 - max - min) : d / (max - min);
-		switch (max) {
-			case rn:
-				h = (gn - bn) / d + (gn < bn ? 6 : 0);
-				break;
-			case gn:
-				h = (bn - rn) / d + 2;
-				break;
-			default:
-				h = (rn - gn) / d + 4;
-		}
-		h /= 6;
-	}
-	return { h, s, l };
+  const rn = r / 255;
+  const gn = g / 255;
+  const bn = b / 255;
+  const max = Math.max(rn, gn, bn);
+  const min = Math.min(rn, gn, bn);
+  const l = (max + min) / 2;
+  let h = 0;
+  let s = 0;
+  if (max !== min) {
+    const d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max - min);
+    switch (max) {
+      case rn:
+        h = (gn - bn) / d + (gn < bn ? 6 : 0);
+        break;
+      case gn:
+        h = (bn - rn) / d + 2;
+        break;
+      default:
+        h = (rn - gn) / d + 4;
+    }
+    h /= 6;
+  }
+  return { h, s, l };
 }
 
 function hslToRgb(h, s, l) {
-	let r;
-	let g;
-	let b;
-	if (s === 0) {
-		r = g = b = l;
-	} else {
-		const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
-		const p = 2 * l - q;
-		const hue2rgb = (t) => {
-			let x = t;
-			if (x < 0) x += 1;
-			if (x > 1) x -= 1;
-			if (x < 1 / 6) return p + (q - p) * 6 * x;
-			if (x < 1 / 2) return q;
-			if (x < 2 / 3) return p + (q - p) * (2 / 3 - x) * 6;
-			return p;
-		};
-		r = hue2rgb(h + 1 / 3);
-		g = hue2rgb(h);
-		b = hue2rgb(h - 1 / 3);
-	}
-	return {
-		r: Math.round(Math.min(255, Math.max(0, r * 255))),
-		g: Math.round(Math.min(255, Math.max(0, g * 255))),
-		b: Math.round(Math.min(255, Math.max(0, b * 255))),
-	};
+  let r;
+  let g;
+  let b;
+  if (s === 0) {
+    r = g = b = l;
+  } else {
+    const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+    const p = 2 * l - q;
+    const hue2rgb = (t) => {
+      let x = t;
+      if (x < 0) x += 1;
+      if (x > 1) x -= 1;
+      if (x < 1 / 6) return p + (q - p) * 6 * x;
+      if (x < 1 / 2) return q;
+      if (x < 2 / 3) return p + (q - p) * (2 / 3 - x) * 6;
+      return p;
+    };
+    r = hue2rgb(h + 1 / 3);
+    g = hue2rgb(h);
+    b = hue2rgb(h - 1 / 3);
+  }
+  return {
+    r: Math.round(Math.min(255, Math.max(0, r * 255))),
+    g: Math.round(Math.min(255, Math.max(0, g * 255))),
+    b: Math.round(Math.min(255, Math.max(0, b * 255))),
+  };
 }
 
 /**
@@ -146,495 +152,542 @@ function hslToRgb(h, s, l) {
  * 僅兩層時外圈對應「三層時第二層」的淺度（u=0.5），不會直接跳到最淺。
  */
 function branchRingFill(input, ring, branchFillDepth) {
-	const rgb = parseAnyColorToRgb(input);
-	if (!rgb) return input;
-	const { h, s } = rgbToHsl(rgb.r, rgb.g, rgb.b);
-	let u = 0;
-	if (branchFillDepth <= 1) {
-		u = 0;
-	} else if (branchFillDepth === 2) {
-		u = (ring - 1) / 2;
-	} else {
-		u = (ring - 1) / (branchFillDepth - 1);
-	}
-	const lDeep = 0.32;
-	const lOut = 0.74;
-	const l2 = lDeep + u * (lOut - lDeep);
-	const satMul = 0.86;
-	const s2 = Math.max(
-		0.30,
-		Math.min(0.86, s * (1 - u * 0.1) * satMul),
-	);
-	const o = hslToRgb(h, s2, l2);
-	return `rgb(${o.r}, ${o.g}, ${o.b})`;
+  const rgb = parseAnyColorToRgb(input);
+  if (!rgb) return input;
+  const { h, s } = rgbToHsl(rgb.r, rgb.g, rgb.b);
+  let u = 0;
+  if (branchFillDepth <= 1) {
+    u = 0;
+  } else if (branchFillDepth === 2) {
+    u = (ring - 1) / 2;
+  } else {
+    u = (ring - 1) / (branchFillDepth - 1);
+  }
+  const lDeep = 0.32;
+  const lOut = 0.74;
+  const l2 = lDeep + u * (lOut - lDeep);
+  const satMul = 0.86;
+  const s2 = Math.max(0.3, Math.min(0.86, s * (1 - u * 0.1) * satMul));
+  const o = hslToRgb(h, s2, l2);
+  return `rgb(${o.r}, ${o.g}, ${o.b})`;
 }
 
 function lighten(hex, ratio = 0.25) {
-	const rgb = parseAnyColorToRgb(hex);
-	if (!rgb) return hex;
-	const r = Math.round(rgb.r + (255 - rgb.r) * ratio);
-	const g = Math.round(rgb.g + (255 - rgb.g) * ratio);
-	const b = Math.round(rgb.b + (255 - rgb.b) * ratio);
-	return `rgb(${r}, ${g}, ${b})`;
+  const rgb = parseAnyColorToRgb(hex);
+  if (!rgb) return hex;
+  const r = Math.round(rgb.r + (255 - rgb.r) * ratio);
+  const g = Math.round(rgb.g + (255 - rgb.g) * ratio);
+  const b = Math.round(rgb.b + (255 - rgb.b) * ratio);
+  return `rgb(${r}, ${g}, ${b})`;
 }
 
 function darken(hex, ratio = 0.18) {
-	const rgb = parseAnyColorToRgb(hex);
-	if (!rgb) return hex;
-	const r = Math.round(rgb.r * (1 - ratio));
-	const g = Math.round(rgb.g * (1 - ratio));
-	const b = Math.round(rgb.b * (1 - ratio));
-	return `rgb(${r}, ${g}, ${b})`;
+  const rgb = parseAnyColorToRgb(hex);
+  if (!rgb) return hex;
+  const r = Math.round(rgb.r * (1 - ratio));
+  const g = Math.round(rgb.g * (1 - ratio));
+  const b = Math.round(rgb.b * (1 - ratio));
+  return `rgb(${r}, ${g}, ${b})`;
 }
 
 function polarToCartesian(cx, cy, r, angleRad) {
-	return {
-		x: cx + r * Math.cos(angleRad),
-		y: cy + r * Math.sin(angleRad),
-	};
+  return {
+    x: cx + r * Math.cos(angleRad),
+    y: cy + r * Math.sin(angleRad),
+  };
 }
 
 function arcPath(cx, cy, innerR, outerR, start, end) {
-	const large = end - start > Math.PI ? 1 : 0;
-	const p1 = polarToCartesian(cx, cy, outerR, start);
-	const p2 = polarToCartesian(cx, cy, outerR, end);
-	const p3 = polarToCartesian(cx, cy, innerR, end);
-	const p4 = polarToCartesian(cx, cy, innerR, start);
-	return [
-		`M ${p1.x} ${p1.y}`,
-		`A ${outerR} ${outerR} 0 ${large} 1 ${p2.x} ${p2.y}`,
-		`L ${p3.x} ${p3.y}`,
-		`A ${innerR} ${innerR} 0 ${large} 0 ${p4.x} ${p4.y}`,
-		"Z",
-	].join(" ");
+  const large = end - start > Math.PI ? 1 : 0;
+  const p1 = polarToCartesian(cx, cy, outerR, start);
+  const p2 = polarToCartesian(cx, cy, outerR, end);
+  const p3 = polarToCartesian(cx, cy, innerR, end);
+  const p4 = polarToCartesian(cx, cy, innerR, start);
+  return [
+    `M ${p1.x} ${p1.y}`,
+    `A ${outerR} ${outerR} 0 ${large} 1 ${p2.x} ${p2.y}`,
+    `L ${p3.x} ${p3.y}`,
+    `A ${innerR} ${innerR} 0 ${large} 0 ${p4.x} ${p4.y}`,
+    "Z",
+  ].join(" ");
 }
 
 function buildSunburstGraph(links) {
-	const children = new Map();
-	const indeg = new Map();
-	const outsum = new Map();
-	for (const l of links) {
-		if (!children.has(l.source)) children.set(l.source, []);
-		children.get(l.source).push({ name: l.target, value: l.value });
-		indeg.set(l.target, (indeg.get(l.target) || 0) + 1);
-		indeg.set(l.source, indeg.get(l.source) || 0);
-		outsum.set(l.source, (outsum.get(l.source) || 0) + l.value);
-	}
-	return { children, indeg, outsum };
+  const children = new Map();
+  const indeg = new Map();
+  const outsum = new Map();
+  for (const l of links) {
+    if (!children.has(l.source)) children.set(l.source, []);
+    children.get(l.source).push({ name: l.target, value: l.value });
+    indeg.set(l.target, (indeg.get(l.target) || 0) + 1);
+    indeg.set(l.source, indeg.get(l.source) || 0);
+    outsum.set(l.source, (outsum.get(l.source) || 0) + l.value);
+  }
+  return { children, indeg, outsum };
 }
 
 function maxTreeDepthFrom(nodeName, children, depth) {
-	const kids = children.get(nodeName);
-	if (!kids || !kids.length) return depth;
-	return Math.max(...kids.map((k) => maxTreeDepthFrom(k.name, children, depth + 1)));
+  const kids = children.get(nodeName);
+  if (!kids || !kids.length) return depth;
+  return Math.max(
+    ...kids.map((k) => maxTreeDepthFrom(k.name, children, depth + 1)),
+  );
 }
 
 const sunburstData = computed(() => {
-	const links = parseLinks(props.series);
-	const W = Math.max(180, chartWidth.value);
-	const H = Math.max(140, chartHeight.value);
-	if (!links.length) return { arcs: [], labels: [], width: W, height: H };
+  const links = parseLinks(props.series);
+  const W = Math.max(180, chartWidth.value);
+  const H = Math.max(140, chartHeight.value);
+  if (!links.length) return { arcs: [], labels: [], width: W, height: H };
 
-	const { children, indeg, outsum } = buildSunburstGraph(links);
+  const { children, indeg, outsum } = buildSunburstGraph(links);
 
-	const roots = [...indeg.keys()].filter((k) => (indeg.get(k) || 0) === 0);
-	const root = roots[0];
-	if (!root) return { arcs: [], labels: [], width: W, height: H };
+  const roots = [...indeg.keys()].filter((k) => (indeg.get(k) || 0) === 0);
+  const root = roots[0];
+  if (!root) return { arcs: [], labels: [], width: W, height: H };
 
-	const level1 = (children.get(root) || []).slice().sort((a, b) => b.value - a.value);
-	const palette = getPalette();
-	const [branchBlue, branchOrange] = getSunburstBranchColors();
-	const branchColor = new Map();
-	level1.forEach((n, i) => {
-		if (i === 0) branchColor.set(n.name, branchBlue);
-		else if (i === 1) branchColor.set(n.name, branchOrange);
-		else branchColor.set(n.name, palette[i % palette.length]);
-	});
+  const level1 = (children.get(root) || [])
+    .slice()
+    .sort((a, b) => b.value - a.value);
+  const palette = getPalette();
+  const [branchBlue, branchOrange] = getSunburstBranchColors();
+  const branchColor = new Map();
+  level1.forEach((n, i) => {
+    if (i === 0) branchColor.set(n.name, branchBlue);
+    else if (i === 1) branchColor.set(n.name, branchOrange);
+    else branchColor.set(n.name, palette[i % palette.length]);
+  });
 
-	const maxRingDepth = Math.max(
-		2,
-		...level1.map((n) => maxTreeDepthFrom(n.name, children, 1)),
-	);
+  const maxRingDepth = Math.max(
+    2,
+    ...level1.map((n) => maxTreeDepthFrom(n.name, children, 1)),
+  );
 
-	let maxLeafVal = 1;
-	for (const [, outs] of children) {
-		for (const { name, value } of outs) {
-			const ch = children.get(name);
-			if (!ch || !ch.length) maxLeafVal = Math.max(maxLeafVal, value);
-		}
-	}
+  let maxLeafVal = 1;
+  for (const [, outs] of children) {
+    for (const { name, value } of outs) {
+      const ch = children.get(name);
+      if (!ch || !ch.length) maxLeafVal = Math.max(maxLeafVal, value);
+    }
+  }
 
-	const total = Math.max(1, outsum.get(root) || level1.reduce((a, b) => a + b.value, 0));
-	const cx = W / 2;
-	const cy = H / 2;
-	const pad = Number(props.chart_config?.sunburst_inset_pad);
-	const inset = Number.isFinite(pad) && pad >= 0 ? pad : 14;
-	const R_max = Math.max(52, Math.min(W, H) / 2 - inset);
-	const rHoleRatio = 0.26;
-	const polarSlack = 1.3;
-	const rHole = R_max * rHoleRatio;
-	const w = (R_max - rHole) / (maxRingDepth + polarSlack);
-	const baseOuter = rHole + maxRingDepth * w;
+  const total = Math.max(
+    1,
+    outsum.get(root) || level1.reduce((a, b) => a + b.value, 0),
+  );
+  const cx = W / 2;
+  const cy = H / 2;
+  const pad = Number(props.chart_config?.sunburst_inset_pad);
+  const inset = Number.isFinite(pad) && pad >= 0 ? pad : 14;
+  const R_max = Math.max(52, Math.min(W, H) / 2 - inset);
+  const rHoleRatio = 0.26;
+  const polarSlack = 1.3;
+  const rHole = R_max * rHoleRatio;
+  const w = (R_max - rHole) / (maxRingDepth + polarSlack);
+  const baseOuter = rHole + maxRingDepth * w;
 
-	const arcs = [];
-	const rawLabels = [];
+  const arcs = [];
+  const rawLabels = [];
 
-	function pushLabel(a0, a1, innerR, outerR, text, ring) {
-		const span = a1 - a0;
-		const avgR = (innerR + outerR) / 2;
-		const need = ring <= 1 ? 40 : ring === 2 ? 36 : 28;
-		if (span * avgR < need) return;
-		const am = (a0 + a1) / 2;
-		const p = polarToCartesian(cx, cy, innerR + (outerR - innerR) * 0.52, am);
-		rawLabels.push({ key: `t-${text}-${ring}-${a0}`, x: p.x, y: p.y, text, ring });
-	}
+  function pushLabel(a0, a1, innerR, outerR, text, ring) {
+    const span = a1 - a0;
+    const avgR = (innerR + outerR) / 2;
+    const need = ring <= 1 ? 40 : ring === 2 ? 36 : 28;
+    if (span * avgR < need) return;
+    const am = (a0 + a1) / 2;
+    const p = polarToCartesian(cx, cy, innerR + (outerR - innerR) * 0.52, am);
+    rawLabels.push({
+      key: `t-${text}-${ring}-${a0}`,
+      x: p.x,
+      y: p.y,
+      text,
+      ring,
+    });
+  }
 
-	function ringBaseOpacity(ring) {
-		if (maxRingDepth <= 1) return 0.96;
-		const t = (ring - 1) / Math.max(1e-6, maxRingDepth - 1);
-		return 0.96 - t * 0.06;
-	}
+  function ringBaseOpacity(ring) {
+    if (maxRingDepth <= 1) return 0.96;
+    const t = (ring - 1) / Math.max(1e-6, maxRingDepth - 1);
+    return 0.96 - t * 0.06;
+  }
 
-	function recurse(parentName, a0, a1, parentRing, branchHex, chain, branchFillDepth) {
-		const kids = (children.get(parentName) || []).slice().sort((a, b) => b.value - a.value);
-		if (!kids.length) return;
-		const pSum = outsum.get(parentName) || kids.reduce((s, x) => s + x.value, 0);
-		let cur = a0;
-		for (const k of kids) {
-			const span = ((a1 - a0) * k.value) / Math.max(1e-6, pSum);
-			const aEnd = cur + span;
-			const sub = children.get(k.name) || [];
-			const childRing = parentRing + 1;
-			const fill = branchRingFill(branchHex, childRing, branchFillDepth);
-			const baseOpacity = ringBaseOpacity(childRing);
-			const pathTip = [...chain, k.name].join(" → ") + `：${k.value}%`;
+  function recurse(
+    parentName,
+    a0,
+    a1,
+    parentRing,
+    branchHex,
+    chain,
+    branchFillDepth,
+  ) {
+    const kids = (children.get(parentName) || [])
+      .slice()
+      .sort((a, b) => b.value - a.value);
+    if (!kids.length) return;
+    const pSum =
+      outsum.get(parentName) || kids.reduce((s, x) => s + x.value, 0);
+    let cur = a0;
+    for (const k of kids) {
+      const span = ((a1 - a0) * k.value) / Math.max(1e-6, pSum);
+      const aEnd = cur + span;
+      const sub = children.get(k.name) || [];
+      const childRing = parentRing + 1;
+      const fill = branchRingFill(branchHex, childRing, branchFillDepth);
+      const baseOpacity = ringBaseOpacity(childRing);
+      const pathTip = [...chain, k.name].join(" → ") + `：${k.value}%`;
 
-			if (sub.length) {
-				const innerR = rHole + (childRing - 1) * w;
-				const outerR = rHole + childRing * w;
-				arcs.push({
-					key: `n-${k.name}-${childRing}-${cur}`,
-					d: arcPath(cx, cy, innerR, outerR, cur, aEnd),
-					fill,
-					ring: childRing,
-					baseOpacity,
-					node: k.name,
-					parent: parentName,
-					title: `${k.name}：${k.value}%`,
-					tooltip: pathTip,
-				});
-				pushLabel(cur, aEnd, innerR, outerR, k.name, childRing);
-				recurse(k.name, cur, aEnd, childRing, branchHex, [...chain, k.name], branchFillDepth);
-			} else {
-				const innerR = rHole + (childRing - 1) * w;
-				const polar = w * (0.12 + 1.18 * (k.value / maxLeafVal));
-				const outerR = baseOuter + polar;
-				arcs.push({
-					key: `leaf-${k.name}-${childRing}-${cur}`,
-					d: arcPath(cx, cy, innerR, outerR, cur, aEnd),
-					fill,
-					ring: childRing,
-					baseOpacity,
-					node: k.name,
-					parent: parentName,
-					title: `${k.name}：${k.value}%`,
-					tooltip: pathTip,
-				});
-				pushLabel(cur, aEnd, innerR, outerR, k.name, childRing);
-			}
-			cur = aEnd;
-		}
-	}
+      if (sub.length) {
+        const innerR = rHole + (childRing - 1) * w;
+        const outerR = rHole + childRing * w;
+        arcs.push({
+          key: `n-${k.name}-${childRing}-${cur}`,
+          d: arcPath(cx, cy, innerR, outerR, cur, aEnd),
+          fill,
+          ring: childRing,
+          baseOpacity,
+          node: k.name,
+          parent: parentName,
+          title: `${k.name}：${k.value}%`,
+          tooltip: pathTip,
+        });
+        pushLabel(cur, aEnd, innerR, outerR, k.name, childRing);
+        recurse(
+          k.name,
+          cur,
+          aEnd,
+          childRing,
+          branchHex,
+          [...chain, k.name],
+          branchFillDepth,
+        );
+      } else {
+        const innerR = rHole + (childRing - 1) * w;
+        const polar = w * (0.12 + 1.18 * (k.value / maxLeafVal));
+        const outerR = baseOuter + polar;
+        arcs.push({
+          key: `leaf-${k.name}-${childRing}-${cur}`,
+          d: arcPath(cx, cy, innerR, outerR, cur, aEnd),
+          fill,
+          ring: childRing,
+          baseOpacity,
+          node: k.name,
+          parent: parentName,
+          title: `${k.name}：${k.value}%`,
+          tooltip: pathTip,
+        });
+        pushLabel(cur, aEnd, innerR, outerR, k.name, childRing);
+      }
+      cur = aEnd;
+    }
+  }
 
-	let a0 = -Math.PI / 2;
-	for (const l1 of level1) {
-		const span1 = (Math.PI * 2 * l1.value) / total;
-		const a1 = a0 + span1;
-		const c1 = branchColor.get(l1.name) || "#7C4DFF";
-		const sub = children.get(l1.name) || [];
-		const branchFillDepth = Math.max(1, maxTreeDepthFrom(l1.name, children, 1));
-		if (sub.length) {
-			const innerR = rHole;
-			const outerR = rHole + w;
-			arcs.push({
-				key: `l1-${l1.name}`,
-				d: arcPath(cx, cy, innerR, outerR, a0, a1),
-				fill: branchRingFill(c1, 1, branchFillDepth),
-				ring: 1,
-				baseOpacity: ringBaseOpacity(1),
-				node: l1.name,
-				parent: root,
-				title: `${l1.name}：${l1.value}%`,
-				tooltip: `${l1.name}：${l1.value}%`,
-			});
-			pushLabel(a0, a1, innerR, outerR, l1.name, 1);
-			recurse(l1.name, a0, a1, 1, c1, [l1.name], branchFillDepth);
-		} else {
-			const polar = w * (0.12 + 1.18 * (l1.value / maxLeafVal));
-			const outerR = baseOuter + polar;
-			arcs.push({
-				key: `l1leaf-${l1.name}`,
-				d: arcPath(cx, cy, rHole, outerR, a0, a1),
-				fill: branchRingFill(c1, 1, branchFillDepth),
-				ring: 1,
-				baseOpacity: ringBaseOpacity(1),
-				node: l1.name,
-				parent: root,
-				title: `${l1.name}：${l1.value}%`,
-				tooltip: `${l1.name}：${l1.value}%`,
-			});
-			pushLabel(a0, a1, rHole, outerR, l1.name, 1);
-		}
-		a0 = a1;
-	}
+  let a0 = -Math.PI / 2;
+  for (const l1 of level1) {
+    const span1 = (Math.PI * 2 * l1.value) / total;
+    const a1 = a0 + span1;
+    const c1 = branchColor.get(l1.name) || "#7C4DFF";
+    const sub = children.get(l1.name) || [];
+    const branchFillDepth = Math.max(1, maxTreeDepthFrom(l1.name, children, 1));
+    if (sub.length) {
+      const innerR = rHole;
+      const outerR = rHole + w;
+      arcs.push({
+        key: `l1-${l1.name}`,
+        d: arcPath(cx, cy, innerR, outerR, a0, a1),
+        fill: branchRingFill(c1, 1, branchFillDepth),
+        ring: 1,
+        baseOpacity: ringBaseOpacity(1),
+        node: l1.name,
+        parent: root,
+        title: `${l1.name}：${l1.value}%`,
+        tooltip: `${l1.name}：${l1.value}%`,
+      });
+      pushLabel(a0, a1, innerR, outerR, l1.name, 1);
+      recurse(l1.name, a0, a1, 1, c1, [l1.name], branchFillDepth);
+    } else {
+      const polar = w * (0.12 + 1.18 * (l1.value / maxLeafVal));
+      const outerR = baseOuter + polar;
+      arcs.push({
+        key: `l1leaf-${l1.name}`,
+        d: arcPath(cx, cy, rHole, outerR, a0, a1),
+        fill: branchRingFill(c1, 1, branchFillDepth),
+        ring: 1,
+        baseOpacity: ringBaseOpacity(1),
+        node: l1.name,
+        parent: root,
+        title: `${l1.name}：${l1.value}%`,
+        tooltip: `${l1.name}：${l1.value}%`,
+      });
+      pushLabel(a0, a1, rHole, outerR, l1.name, 1);
+    }
+    a0 = a1;
+  }
 
-	const labels = [];
-	const boxPaddingX = 8;
-	const boxH = 14;
-	for (const it of rawLabels) {
-		const boxW = Math.max(16, it.text.length * 13 * 0.62 + boxPaddingX);
-		const box = {
-			left: it.x - boxW / 2,
-			right: it.x + boxW / 2,
-			top: it.y - boxH / 2,
-			bottom: it.y + boxH / 2,
-		};
-		const overlapped = labels.some((ex) => {
-			const eb = ex._box;
-			return !(
-				box.right < eb.left ||
-				box.left > eb.right ||
-				box.bottom < eb.top ||
-				box.top > eb.bottom
-			);
-		});
-		if (!overlapped) labels.push({ ...it, _box: box });
-	}
+  const labels = [];
+  const boxPaddingX = 8;
+  const boxH = 14;
+  for (const it of rawLabels) {
+    const boxW = Math.max(16, it.text.length * 13 * 0.62 + boxPaddingX);
+    const box = {
+      left: it.x - boxW / 2,
+      right: it.x + boxW / 2,
+      top: it.y - boxH / 2,
+      bottom: it.y + boxH / 2,
+    };
+    const overlapped = labels.some((ex) => {
+      const eb = ex._box;
+      return !(
+        box.right < eb.left ||
+        box.left > eb.right ||
+        box.bottom < eb.top ||
+        box.top > eb.bottom
+      );
+    });
+    if (!overlapped) labels.push({ ...it, _box: box });
+  }
 
-	const childrenByNode = {};
-	const parentByNode = {};
-	for (const [k, arr] of children.entries()) {
-		childrenByNode[k] = arr.map((x) => x.name);
-		for (const x of arr) parentByNode[x.name] = k;
-	}
+  const childrenByNode = {};
+  const parentByNode = {};
+  for (const [k, arr] of children.entries()) {
+    childrenByNode[k] = arr.map((x) => x.name);
+    for (const x of arr) parentByNode[x.name] = k;
+  }
 
-	return { arcs, labels, width: W, height: H, childrenByNode, parentByNode };
+  return { arcs, labels, width: W, height: H, childrenByNode, parentByNode };
 });
 
 function updateSize() {
-	const w = wrapRef.value?.clientWidth || 420;
-	const h = wrapRef.value?.clientHeight || 260;
-	chartWidth.value = w;
-	chartHeight.value = h;
+  const w = wrapRef.value?.clientWidth || 420;
+  const h = wrapRef.value?.clientHeight || 260;
+  chartWidth.value = w;
+  chartHeight.value = h;
 }
 
 function onArcHoverMove(evt, arc) {
-	if (!wrapRef.value || !arc) return;
-	const text = arc.tooltip || arc.title || "";
-	const pad = 8;
-	const g = 4;
-	const vw = window.innerWidth;
-	const vh = window.innerHeight;
-	const maxW = Math.min(400, vw - 2 * pad);
-	const estW = Math.max(140, Math.min(maxW, text.length * 13 + 28));
-	const lineCount = Math.max(1, Math.ceil((text.length * 13) / estW));
-	const estH = Math.min(vh - 2 * pad, lineCount * 22 + 20);
+  if (!wrapRef.value || !arc) return;
+  const text = arc.tooltip || arc.title || "";
+  const pad = 8;
+  const g = 4;
+  const vw = window.innerWidth;
+  const vh = window.innerHeight;
+  const maxW = Math.min(400, vw - 2 * pad);
+  const estW = Math.max(140, Math.min(maxW, text.length * 13 + 28));
+  const lineCount = Math.max(1, Math.ceil((text.length * 13) / estW));
+  const estH = Math.min(vh - 2 * pad, lineCount * 22 + 20);
 
-	const roomAbove = evt.clientY - pad >= estH + g;
-	const roomBelow = vh - pad - evt.clientY >= estH + g;
-	const placeAbove = roomAbove || !roomBelow;
+  const roomAbove = evt.clientY - pad >= estH + g;
+  const roomBelow = vh - pad - evt.clientY >= estH + g;
+  const placeAbove = roomAbove || !roomBelow;
 
-	const roomRight = vw - pad - evt.clientX >= estW + g;
-	const roomLeft = evt.clientX - pad >= estW + g;
-	let placeLeft = false;
-	if (!roomRight && roomLeft) placeLeft = true;
-	else if (roomRight && roomLeft) placeLeft = evt.clientX > vw * 0.5;
-	else if (!roomRight && !roomLeft) placeLeft = evt.clientX + estW / 2 > vw * 0.5;
+  const roomRight = vw - pad - evt.clientX >= estW + g;
+  const roomLeft = evt.clientX - pad >= estW + g;
+  let placeLeft = false;
+  if (!roomRight && roomLeft) placeLeft = true;
+  else if (roomRight && roomLeft) placeLeft = evt.clientX > vw * 0.5;
+  else if (!roomRight && !roomLeft)
+    placeLeft = evt.clientX + estW / 2 > vw * 0.5;
 
-	hoverTip.value = {
-		show: true,
-		x: evt.clientX,
-		y: evt.clientY,
-		text,
-		placeLeft,
-		placeAbove,
-	};
-	hoveredNode.value = arc.node || "";
+  hoverTip.value = {
+    show: true,
+    x: evt.clientX,
+    y: evt.clientY,
+    text,
+    placeLeft,
+    placeAbove,
+  };
+  hoveredNode.value = arc.node || "";
 }
 
 function onArcHoverLeave() {
-	hoverTip.value.show = false;
-	hoveredNode.value = "";
+  hoverTip.value.show = false;
+  hoveredNode.value = "";
 }
 
 function highlightSet() {
-	const root = hoveredNode.value;
-	if (!root) return null;
-	const set = new Set([root]);
-	const childrenByNode = sunburstData.value.childrenByNode || {};
-	const parentByNode = sunburstData.value.parentByNode || {};
+  const root = hoveredNode.value;
+  if (!root) return null;
+  const set = new Set([root]);
+  const childrenByNode = sunburstData.value.childrenByNode || {};
+  const parentByNode = sunburstData.value.parentByNode || {};
 
-	// Descendants: hover parent => all next layers glow together.
-	const q = [root];
-	while (q.length) {
-		const n = q.shift();
-		const kids = childrenByNode[n] || [];
-		for (const k of kids) {
-			if (!set.has(k)) {
-				set.add(k);
-				q.push(k);
-			}
-		}
-	}
+  // Descendants: hover parent => all next layers glow together.
+  const q = [root];
+  while (q.length) {
+    const n = q.shift();
+    const kids = childrenByNode[n] || [];
+    for (const k of kids) {
+      if (!set.has(k)) {
+        set.add(k);
+        q.push(k);
+      }
+    }
+  }
 
-	// Ancestors: keep path readable.
-	let p = parentByNode[root];
-	while (p) {
-		set.add(p);
-		p = parentByNode[p];
-	}
-	return set;
+  // Ancestors: keep path readable.
+  let p = parentByNode[root];
+  while (p) {
+    set.add(p);
+    p = parentByNode[p];
+  }
+  return set;
 }
 
 function arcFill(arc) {
-	const hs = highlightSet();
-	if (!hs) return arc.fill;
-	return hs.has(arc.node) ? lighten(arc.fill, 0.1) : darken(arc.fill, 0.16);
+  const hs = highlightSet();
+  if (!hs) return arc.fill;
+  return hs.has(arc.node) ? lighten(arc.fill, 0.1) : darken(arc.fill, 0.16);
 }
 
 function arcOpacity(arc) {
-	const hs = highlightSet();
-	const base = arc.baseOpacity ?? 0.9;
-	if (!hs) return base;
-	return hs.has(arc.node) ? Math.min(0.99, base + 0.06) : Math.max(0.26, base * 0.52);
+  const hs = highlightSet();
+  const base = arc.baseOpacity ?? 0.9;
+  if (!hs) return base;
+  return hs.has(arc.node)
+    ? Math.min(0.99, base + 0.06)
+    : Math.max(0.26, base * 0.52);
 }
 
 onMounted(() => {
-	updateSize();
-	resizeObserver = new ResizeObserver(updateSize);
-	if (wrapRef.value) resizeObserver.observe(wrapRef.value);
+  updateSize();
+  resizeObserver = new ResizeObserver(updateSize);
+  if (wrapRef.value) resizeObserver.observe(wrapRef.value);
 });
 
 onBeforeUnmount(() => {
-	if (resizeObserver) resizeObserver.disconnect();
+  if (resizeObserver) resizeObserver.disconnect();
 });
 </script>
 
 <template>
-	<div v-if="activeChart === 'SunburstChart'" ref="wrapRef" class="sunburstchart">
-		<div class="sunburstchart__svg-clip">
-			<svg :viewBox="`0 0 ${sunburstData.width} ${sunburstData.height}`" width="100%" height="100%">
-			<g>
-				<path
-					v-for="a in sunburstData.arcs"
-					:key="a.key"
-					:d="a.d"
-					class="sunburstchart__arc"
-					:fill="arcFill(a)"
-					:fill-opacity="arcOpacity(a)"
-					role="img"
-					:aria-label="a.title"
-					@mouseenter="(evt) => onArcHoverMove(evt, a)"
-					@mousemove="(evt) => onArcHoverMove(evt, a)"
-					@mouseleave="onArcHoverLeave"
-				/>
-			</g>
-			<g>
-				<text
-					v-for="t in sunburstData.labels"
-					:key="t.key"
-					:x="t.x"
-					:y="t.y"
-					class="sunburstchart__label"
-					text-anchor="middle"
-					dominant-baseline="middle"
-				>
-					{{ t.text }}
-				</text>
-			</g>
-		</svg>
-		</div>
-		<div
-			v-if="hoverTip.show"
-			class="sunburstchart__hover"
-			:class="{
-				'sunburstchart__hover--tl': hoverTip.placeLeft && hoverTip.placeAbove,
-				'sunburstchart__hover--tr': !hoverTip.placeLeft && hoverTip.placeAbove,
-				'sunburstchart__hover--bl': hoverTip.placeLeft && !hoverTip.placeAbove,
-				'sunburstchart__hover--br': !hoverTip.placeLeft && !hoverTip.placeAbove,
-			}"
-			:style="{ left: `${hoverTip.x}px`, top: `${hoverTip.y}px` }"
-		>
-			{{ hoverTip.text }}
-		</div>
-	</div>
+  <div
+    v-if="activeChart === 'SunburstChart'"
+    ref="wrapRef"
+    class="sunburstchart"
+  >
+    <div class="sunburstchart__svg-clip">
+      <svg
+        :viewBox="`0 0 ${sunburstData.width} ${sunburstData.height}`"
+        width="100%"
+        height="100%"
+      >
+        <g>
+          <path
+            v-for="a in sunburstData.arcs"
+            :key="a.key"
+            :d="a.d"
+            class="sunburstchart__arc"
+            :fill="arcFill(a)"
+            :fill-opacity="arcOpacity(a)"
+            role="img"
+            :aria-label="a.title"
+            @mouseenter="(evt) => onArcHoverMove(evt, a)"
+            @mousemove="(evt) => onArcHoverMove(evt, a)"
+            @mouseleave="onArcHoverLeave"
+          />
+        </g>
+        <g>
+          <text
+            v-for="t in sunburstData.labels"
+            :key="t.key"
+            :x="t.x"
+            :y="t.y"
+            class="sunburstchart__label"
+            text-anchor="middle"
+            dominant-baseline="middle"
+          >
+            {{ t.text }}
+          </text>
+        </g>
+      </svg>
+    </div>
+    <div
+      v-if="hoverTip.show"
+      class="sunburstchart__hover"
+      :class="{
+        'sunburstchart__hover--tl': hoverTip.placeLeft && hoverTip.placeAbove,
+        'sunburstchart__hover--tr': !hoverTip.placeLeft && hoverTip.placeAbove,
+        'sunburstchart__hover--bl': hoverTip.placeLeft && !hoverTip.placeAbove,
+        'sunburstchart__hover--br': !hoverTip.placeLeft && !hoverTip.placeAbove,
+      }"
+      :style="{ left: `${hoverTip.x}px`, top: `${hoverTip.y}px` }"
+    >
+      {{ hoverTip.text }}
+    </div>
+  </div>
 </template>
 
 <style scoped lang="scss">
 .sunburstchart {
-	width: 100%;
-	height: 100%;
-	position: relative;
-	overflow: visible;
+  width: 100%;
+  height: 100%;
+  position: relative;
+  overflow: visible;
 }
 
 /* 只裁切圖形；hover 用 fixed 畫在視窗上，不受父層 overflow 遮住 */
 .sunburstchart__svg-clip {
-	width: 100%;
-	height: 100%;
-	overflow: hidden;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
 }
 
 .sunburstchart__label {
-	font-family: "微軟正黑體", "Microsoft JhengHei", "Droid Sans", "Open Sans",
-		"Helvetica", sans-serif;
-	font-size: 14px;
-	font-weight: 700;
-	fill: #e6edf5;
-	paint-order: stroke;
-	stroke: rgba(23, 28, 36, 0.42);
-	stroke-width: 1px;
-	pointer-events: none;
+  font-family:
+    "微軟正黑體", "Microsoft JhengHei", "Droid Sans", "Open Sans", "Helvetica",
+    sans-serif;
+  font-size: 14px;
+  font-weight: 700;
+  fill: #e6edf5;
+  paint-order: stroke;
+  stroke: rgba(23, 28, 36, 0.42);
+  stroke-width: 1px;
+  pointer-events: none;
 }
 
 .sunburstchart__arc {
-	stroke: rgba(120, 120, 120, 0.65);
-	stroke-width: 1;
-	transition: fill 180ms ease, fill-opacity 180ms ease;
+  stroke: rgba(120, 120, 120, 0.65);
+  stroke-width: 1;
+  transition:
+    fill 180ms ease,
+    fill-opacity 180ms ease;
 }
 
 .sunburstchart__hover {
-	--tip-gap: 4px;
-	position: fixed;
-	margin: 0;
-	background: rgba(8, 11, 18, 0.92);
-	color: #fff;
-	font-family: "微軟正黑體", "Microsoft JhengHei", "Droid Sans", "Open Sans",
-		"Helvetica", sans-serif;
-	font-size: 14px;
-	font-weight: 700;
-	padding: 8px 12px;
-	border-radius: 6px;
-	border: 1px solid rgba(255, 255, 255, 0.2);
-	pointer-events: none;
-	white-space: normal;
-	word-break: break-word;
-	line-height: 1.4;
-	max-width: min(400px, calc(100vw - 20px));
-	z-index: 10050;
-	box-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
-	/* 錨在游標 (left/top)；translate 讓框緣距游標固定為 --tip-gap，左右象限對稱 */
-	&--tr {
-		transform: translate(var(--tip-gap), calc(-100% - var(--tip-gap)));
-	}
-	&--tl {
-		transform: translate(calc(-100% - var(--tip-gap)), calc(-100% - var(--tip-gap)));
-	}
-	&--br {
-		transform: translate(var(--tip-gap), var(--tip-gap));
-	}
-	&--bl {
-		transform: translate(calc(-100% - var(--tip-gap)), var(--tip-gap));
-	}
+  --tip-gap: 4px;
+  position: fixed;
+  margin: 0;
+  background: rgba(8, 11, 18, 0.92);
+  color: #fff;
+  font-family:
+    "微軟正黑體", "Microsoft JhengHei", "Droid Sans", "Open Sans", "Helvetica",
+    sans-serif;
+  font-size: 14px;
+  font-weight: 700;
+  padding: 8px 12px;
+  border-radius: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  pointer-events: none;
+  white-space: normal;
+  word-break: break-word;
+  line-height: 1.4;
+  max-width: min(400px, calc(100vw - 20px));
+  z-index: 10050;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
+  /* 錨在游標 (left/top)；translate 讓框緣距游標固定為 --tip-gap，左右象限對稱 */
+  &--tr {
+    transform: translate(var(--tip-gap), calc(-100% - var(--tip-gap)));
+  }
+  &--tl {
+    transform: translate(
+      calc(-100% - var(--tip-gap)),
+      calc(-100% - var(--tip-gap))
+    );
+  }
+  &--br {
+    transform: translate(var(--tip-gap), var(--tip-gap));
+  }
+  &--bl {
+    transform: translate(calc(-100% - var(--tip-gap)), var(--tip-gap));
+  }
 }
 </style>

--- a/SunburstChart.vue
+++ b/SunburstChart.vue
@@ -1,0 +1,640 @@
+<script setup>
+import { computed, onBeforeUnmount, onMounted, ref } from "vue";
+
+const props = defineProps([
+	"chart_config",
+	"activeChart",
+	"series",
+	"map_config",
+	"map_filter",
+	"map_filter_on",
+]);
+
+const wrapRef = ref(null);
+const chartWidth = ref(420);
+const chartHeight = ref(260);
+let resizeObserver = null;
+const hoverTip = ref({
+	show: false,
+	x: 0,
+	y: 0,
+	text: "",
+	placeLeft: false,
+	placeAbove: true,
+});
+const hoveredNode = ref("");
+
+function normalizeRows(raw) {
+	if (Array.isArray(raw)) return raw;
+	if (!raw || typeof raw !== "object") return [];
+	const wrapped = raw.data || raw.rows || raw.items || raw.series || raw.result || null;
+	return Array.isArray(wrapped) ? wrapped : [];
+}
+
+function parseLinks(raw) {
+	const rows = Array.isArray(raw?.edges) ? raw.edges : normalizeRows(raw);
+	return rows
+		.map((it) => ({
+			source: String(it.source ?? it.from ?? it.x_axis ?? it.x ?? "").trim(),
+			target: String(it.target ?? it.to ?? it.y_axis ?? "").trim(),
+			value: Number(it.value ?? it.data ?? it.y ?? 0),
+			color: it.color ? String(it.color) : null,
+		}))
+		.filter((it) => it.source && it.target && Number.isFinite(it.value) && it.value > 0);
+}
+
+function getPalette() {
+	const c = props.chart_config?.color;
+	if (Array.isArray(c) && c.length > 0) return c;
+	return ["#4EA3FF", "#F5A623", "#7C4DFF", "#56B96D", "#E170A6", "#AF4137"];
+}
+
+function getSunburstBranchColors() {
+	const cfg = props.chart_config?.sunburst_branch_colors;
+	if (
+		Array.isArray(cfg) &&
+		cfg.length >= 2 &&
+		cfg.every((x) => typeof x === "string" && x.trim())
+	) {
+		return [cfg[0], cfg[1]];
+	}
+	// Default branch colors requested by design: blue + orange.
+	return ["#4EA3FF", "#F5A623"];
+}
+
+function hexToRgb(hex) {
+	const s = String(hex || "").replace("#", "");
+	if (s.length !== 6) return null;
+	const n = Number.parseInt(s, 16);
+	if (!Number.isFinite(n)) return null;
+	return { r: (n >> 16) & 255, g: (n >> 8) & 255, b: n & 255 };
+}
+
+function parseAnyColorToRgb(input) {
+	const s = String(input || "").trim();
+	if (!s) return null;
+	const hex = hexToRgb(s);
+	if (hex) return hex;
+	const m = s.match(/^rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/i);
+	if (m) {
+		const r = Number(m[1]);
+		const g = Number(m[2]);
+		const b = Number(m[3]);
+		if ([r, g, b].every((n) => n >= 0 && n <= 255)) return { r, g, b };
+	}
+	return null;
+}
+
+function rgbToHsl(r, g, b) {
+	const rn = r / 255;
+	const gn = g / 255;
+	const bn = b / 255;
+	const max = Math.max(rn, gn, bn);
+	const min = Math.min(rn, gn, bn);
+	const l = (max + min) / 2;
+	let h = 0;
+	let s = 0;
+	if (max !== min) {
+		const d = max - min;
+		s = l > 0.5 ? d / (2 - max - min) : d / (max - min);
+		switch (max) {
+			case rn:
+				h = (gn - bn) / d + (gn < bn ? 6 : 0);
+				break;
+			case gn:
+				h = (bn - rn) / d + 2;
+				break;
+			default:
+				h = (rn - gn) / d + 4;
+		}
+		h /= 6;
+	}
+	return { h, s, l };
+}
+
+function hslToRgb(h, s, l) {
+	let r;
+	let g;
+	let b;
+	if (s === 0) {
+		r = g = b = l;
+	} else {
+		const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+		const p = 2 * l - q;
+		const hue2rgb = (t) => {
+			let x = t;
+			if (x < 0) x += 1;
+			if (x > 1) x -= 1;
+			if (x < 1 / 6) return p + (q - p) * 6 * x;
+			if (x < 1 / 2) return q;
+			if (x < 2 / 3) return p + (q - p) * (2 / 3 - x) * 6;
+			return p;
+		};
+		r = hue2rgb(h + 1 / 3);
+		g = hue2rgb(h);
+		b = hue2rgb(h - 1 / 3);
+	}
+	return {
+		r: Math.round(Math.min(255, Math.max(0, r * 255))),
+		g: Math.round(Math.min(255, Math.max(0, g * 255))),
+		b: Math.round(Math.min(255, Math.max(0, b * 255))),
+	};
+}
+
+/**
+ * 同一分支色相：第 1 環最深，愈外愈淺。
+ * 僅兩層時外圈對應「三層時第二層」的淺度（u=0.5），不會直接跳到最淺。
+ */
+function branchRingFill(input, ring, branchFillDepth) {
+	const rgb = parseAnyColorToRgb(input);
+	if (!rgb) return input;
+	const { h, s } = rgbToHsl(rgb.r, rgb.g, rgb.b);
+	let u = 0;
+	if (branchFillDepth <= 1) {
+		u = 0;
+	} else if (branchFillDepth === 2) {
+		u = (ring - 1) / 2;
+	} else {
+		u = (ring - 1) / (branchFillDepth - 1);
+	}
+	const lDeep = 0.32;
+	const lOut = 0.74;
+	const l2 = lDeep + u * (lOut - lDeep);
+	const satMul = 0.86;
+	const s2 = Math.max(
+		0.30,
+		Math.min(0.86, s * (1 - u * 0.1) * satMul),
+	);
+	const o = hslToRgb(h, s2, l2);
+	return `rgb(${o.r}, ${o.g}, ${o.b})`;
+}
+
+function lighten(hex, ratio = 0.25) {
+	const rgb = parseAnyColorToRgb(hex);
+	if (!rgb) return hex;
+	const r = Math.round(rgb.r + (255 - rgb.r) * ratio);
+	const g = Math.round(rgb.g + (255 - rgb.g) * ratio);
+	const b = Math.round(rgb.b + (255 - rgb.b) * ratio);
+	return `rgb(${r}, ${g}, ${b})`;
+}
+
+function darken(hex, ratio = 0.18) {
+	const rgb = parseAnyColorToRgb(hex);
+	if (!rgb) return hex;
+	const r = Math.round(rgb.r * (1 - ratio));
+	const g = Math.round(rgb.g * (1 - ratio));
+	const b = Math.round(rgb.b * (1 - ratio));
+	return `rgb(${r}, ${g}, ${b})`;
+}
+
+function polarToCartesian(cx, cy, r, angleRad) {
+	return {
+		x: cx + r * Math.cos(angleRad),
+		y: cy + r * Math.sin(angleRad),
+	};
+}
+
+function arcPath(cx, cy, innerR, outerR, start, end) {
+	const large = end - start > Math.PI ? 1 : 0;
+	const p1 = polarToCartesian(cx, cy, outerR, start);
+	const p2 = polarToCartesian(cx, cy, outerR, end);
+	const p3 = polarToCartesian(cx, cy, innerR, end);
+	const p4 = polarToCartesian(cx, cy, innerR, start);
+	return [
+		`M ${p1.x} ${p1.y}`,
+		`A ${outerR} ${outerR} 0 ${large} 1 ${p2.x} ${p2.y}`,
+		`L ${p3.x} ${p3.y}`,
+		`A ${innerR} ${innerR} 0 ${large} 0 ${p4.x} ${p4.y}`,
+		"Z",
+	].join(" ");
+}
+
+function buildSunburstGraph(links) {
+	const children = new Map();
+	const indeg = new Map();
+	const outsum = new Map();
+	for (const l of links) {
+		if (!children.has(l.source)) children.set(l.source, []);
+		children.get(l.source).push({ name: l.target, value: l.value });
+		indeg.set(l.target, (indeg.get(l.target) || 0) + 1);
+		indeg.set(l.source, indeg.get(l.source) || 0);
+		outsum.set(l.source, (outsum.get(l.source) || 0) + l.value);
+	}
+	return { children, indeg, outsum };
+}
+
+function maxTreeDepthFrom(nodeName, children, depth) {
+	const kids = children.get(nodeName);
+	if (!kids || !kids.length) return depth;
+	return Math.max(...kids.map((k) => maxTreeDepthFrom(k.name, children, depth + 1)));
+}
+
+const sunburstData = computed(() => {
+	const links = parseLinks(props.series);
+	const W = Math.max(180, chartWidth.value);
+	const H = Math.max(140, chartHeight.value);
+	if (!links.length) return { arcs: [], labels: [], width: W, height: H };
+
+	const { children, indeg, outsum } = buildSunburstGraph(links);
+
+	const roots = [...indeg.keys()].filter((k) => (indeg.get(k) || 0) === 0);
+	const root = roots[0];
+	if (!root) return { arcs: [], labels: [], width: W, height: H };
+
+	const level1 = (children.get(root) || []).slice().sort((a, b) => b.value - a.value);
+	const palette = getPalette();
+	const [branchBlue, branchOrange] = getSunburstBranchColors();
+	const branchColor = new Map();
+	level1.forEach((n, i) => {
+		if (i === 0) branchColor.set(n.name, branchBlue);
+		else if (i === 1) branchColor.set(n.name, branchOrange);
+		else branchColor.set(n.name, palette[i % palette.length]);
+	});
+
+	const maxRingDepth = Math.max(
+		2,
+		...level1.map((n) => maxTreeDepthFrom(n.name, children, 1)),
+	);
+
+	let maxLeafVal = 1;
+	for (const [, outs] of children) {
+		for (const { name, value } of outs) {
+			const ch = children.get(name);
+			if (!ch || !ch.length) maxLeafVal = Math.max(maxLeafVal, value);
+		}
+	}
+
+	const total = Math.max(1, outsum.get(root) || level1.reduce((a, b) => a + b.value, 0));
+	const cx = W / 2;
+	const cy = H / 2;
+	const pad = Number(props.chart_config?.sunburst_inset_pad);
+	const inset = Number.isFinite(pad) && pad >= 0 ? pad : 14;
+	const R_max = Math.max(52, Math.min(W, H) / 2 - inset);
+	const rHoleRatio = 0.26;
+	const polarSlack = 1.3;
+	const rHole = R_max * rHoleRatio;
+	const w = (R_max - rHole) / (maxRingDepth + polarSlack);
+	const baseOuter = rHole + maxRingDepth * w;
+
+	const arcs = [];
+	const rawLabels = [];
+
+	function pushLabel(a0, a1, innerR, outerR, text, ring) {
+		const span = a1 - a0;
+		const avgR = (innerR + outerR) / 2;
+		const need = ring <= 1 ? 40 : ring === 2 ? 36 : 28;
+		if (span * avgR < need) return;
+		const am = (a0 + a1) / 2;
+		const p = polarToCartesian(cx, cy, innerR + (outerR - innerR) * 0.52, am);
+		rawLabels.push({ key: `t-${text}-${ring}-${a0}`, x: p.x, y: p.y, text, ring });
+	}
+
+	function ringBaseOpacity(ring) {
+		if (maxRingDepth <= 1) return 0.96;
+		const t = (ring - 1) / Math.max(1e-6, maxRingDepth - 1);
+		return 0.96 - t * 0.06;
+	}
+
+	function recurse(parentName, a0, a1, parentRing, branchHex, chain, branchFillDepth) {
+		const kids = (children.get(parentName) || []).slice().sort((a, b) => b.value - a.value);
+		if (!kids.length) return;
+		const pSum = outsum.get(parentName) || kids.reduce((s, x) => s + x.value, 0);
+		let cur = a0;
+		for (const k of kids) {
+			const span = ((a1 - a0) * k.value) / Math.max(1e-6, pSum);
+			const aEnd = cur + span;
+			const sub = children.get(k.name) || [];
+			const childRing = parentRing + 1;
+			const fill = branchRingFill(branchHex, childRing, branchFillDepth);
+			const baseOpacity = ringBaseOpacity(childRing);
+			const pathTip = [...chain, k.name].join(" → ") + `：${k.value}%`;
+
+			if (sub.length) {
+				const innerR = rHole + (childRing - 1) * w;
+				const outerR = rHole + childRing * w;
+				arcs.push({
+					key: `n-${k.name}-${childRing}-${cur}`,
+					d: arcPath(cx, cy, innerR, outerR, cur, aEnd),
+					fill,
+					ring: childRing,
+					baseOpacity,
+					node: k.name,
+					parent: parentName,
+					title: `${k.name}：${k.value}%`,
+					tooltip: pathTip,
+				});
+				pushLabel(cur, aEnd, innerR, outerR, k.name, childRing);
+				recurse(k.name, cur, aEnd, childRing, branchHex, [...chain, k.name], branchFillDepth);
+			} else {
+				const innerR = rHole + (childRing - 1) * w;
+				const polar = w * (0.12 + 1.18 * (k.value / maxLeafVal));
+				const outerR = baseOuter + polar;
+				arcs.push({
+					key: `leaf-${k.name}-${childRing}-${cur}`,
+					d: arcPath(cx, cy, innerR, outerR, cur, aEnd),
+					fill,
+					ring: childRing,
+					baseOpacity,
+					node: k.name,
+					parent: parentName,
+					title: `${k.name}：${k.value}%`,
+					tooltip: pathTip,
+				});
+				pushLabel(cur, aEnd, innerR, outerR, k.name, childRing);
+			}
+			cur = aEnd;
+		}
+	}
+
+	let a0 = -Math.PI / 2;
+	for (const l1 of level1) {
+		const span1 = (Math.PI * 2 * l1.value) / total;
+		const a1 = a0 + span1;
+		const c1 = branchColor.get(l1.name) || "#7C4DFF";
+		const sub = children.get(l1.name) || [];
+		const branchFillDepth = Math.max(1, maxTreeDepthFrom(l1.name, children, 1));
+		if (sub.length) {
+			const innerR = rHole;
+			const outerR = rHole + w;
+			arcs.push({
+				key: `l1-${l1.name}`,
+				d: arcPath(cx, cy, innerR, outerR, a0, a1),
+				fill: branchRingFill(c1, 1, branchFillDepth),
+				ring: 1,
+				baseOpacity: ringBaseOpacity(1),
+				node: l1.name,
+				parent: root,
+				title: `${l1.name}：${l1.value}%`,
+				tooltip: `${l1.name}：${l1.value}%`,
+			});
+			pushLabel(a0, a1, innerR, outerR, l1.name, 1);
+			recurse(l1.name, a0, a1, 1, c1, [l1.name], branchFillDepth);
+		} else {
+			const polar = w * (0.12 + 1.18 * (l1.value / maxLeafVal));
+			const outerR = baseOuter + polar;
+			arcs.push({
+				key: `l1leaf-${l1.name}`,
+				d: arcPath(cx, cy, rHole, outerR, a0, a1),
+				fill: branchRingFill(c1, 1, branchFillDepth),
+				ring: 1,
+				baseOpacity: ringBaseOpacity(1),
+				node: l1.name,
+				parent: root,
+				title: `${l1.name}：${l1.value}%`,
+				tooltip: `${l1.name}：${l1.value}%`,
+			});
+			pushLabel(a0, a1, rHole, outerR, l1.name, 1);
+		}
+		a0 = a1;
+	}
+
+	const labels = [];
+	const boxPaddingX = 8;
+	const boxH = 14;
+	for (const it of rawLabels) {
+		const boxW = Math.max(16, it.text.length * 13 * 0.62 + boxPaddingX);
+		const box = {
+			left: it.x - boxW / 2,
+			right: it.x + boxW / 2,
+			top: it.y - boxH / 2,
+			bottom: it.y + boxH / 2,
+		};
+		const overlapped = labels.some((ex) => {
+			const eb = ex._box;
+			return !(
+				box.right < eb.left ||
+				box.left > eb.right ||
+				box.bottom < eb.top ||
+				box.top > eb.bottom
+			);
+		});
+		if (!overlapped) labels.push({ ...it, _box: box });
+	}
+
+	const childrenByNode = {};
+	const parentByNode = {};
+	for (const [k, arr] of children.entries()) {
+		childrenByNode[k] = arr.map((x) => x.name);
+		for (const x of arr) parentByNode[x.name] = k;
+	}
+
+	return { arcs, labels, width: W, height: H, childrenByNode, parentByNode };
+});
+
+function updateSize() {
+	const w = wrapRef.value?.clientWidth || 420;
+	const h = wrapRef.value?.clientHeight || 260;
+	chartWidth.value = w;
+	chartHeight.value = h;
+}
+
+function onArcHoverMove(evt, arc) {
+	if (!wrapRef.value || !arc) return;
+	const text = arc.tooltip || arc.title || "";
+	const pad = 8;
+	const g = 4;
+	const vw = window.innerWidth;
+	const vh = window.innerHeight;
+	const maxW = Math.min(400, vw - 2 * pad);
+	const estW = Math.max(140, Math.min(maxW, text.length * 13 + 28));
+	const lineCount = Math.max(1, Math.ceil((text.length * 13) / estW));
+	const estH = Math.min(vh - 2 * pad, lineCount * 22 + 20);
+
+	const roomAbove = evt.clientY - pad >= estH + g;
+	const roomBelow = vh - pad - evt.clientY >= estH + g;
+	const placeAbove = roomAbove || !roomBelow;
+
+	const roomRight = vw - pad - evt.clientX >= estW + g;
+	const roomLeft = evt.clientX - pad >= estW + g;
+	let placeLeft = false;
+	if (!roomRight && roomLeft) placeLeft = true;
+	else if (roomRight && roomLeft) placeLeft = evt.clientX > vw * 0.5;
+	else if (!roomRight && !roomLeft) placeLeft = evt.clientX + estW / 2 > vw * 0.5;
+
+	hoverTip.value = {
+		show: true,
+		x: evt.clientX,
+		y: evt.clientY,
+		text,
+		placeLeft,
+		placeAbove,
+	};
+	hoveredNode.value = arc.node || "";
+}
+
+function onArcHoverLeave() {
+	hoverTip.value.show = false;
+	hoveredNode.value = "";
+}
+
+function highlightSet() {
+	const root = hoveredNode.value;
+	if (!root) return null;
+	const set = new Set([root]);
+	const childrenByNode = sunburstData.value.childrenByNode || {};
+	const parentByNode = sunburstData.value.parentByNode || {};
+
+	// Descendants: hover parent => all next layers glow together.
+	const q = [root];
+	while (q.length) {
+		const n = q.shift();
+		const kids = childrenByNode[n] || [];
+		for (const k of kids) {
+			if (!set.has(k)) {
+				set.add(k);
+				q.push(k);
+			}
+		}
+	}
+
+	// Ancestors: keep path readable.
+	let p = parentByNode[root];
+	while (p) {
+		set.add(p);
+		p = parentByNode[p];
+	}
+	return set;
+}
+
+function arcFill(arc) {
+	const hs = highlightSet();
+	if (!hs) return arc.fill;
+	return hs.has(arc.node) ? lighten(arc.fill, 0.1) : darken(arc.fill, 0.16);
+}
+
+function arcOpacity(arc) {
+	const hs = highlightSet();
+	const base = arc.baseOpacity ?? 0.9;
+	if (!hs) return base;
+	return hs.has(arc.node) ? Math.min(0.99, base + 0.06) : Math.max(0.26, base * 0.52);
+}
+
+onMounted(() => {
+	updateSize();
+	resizeObserver = new ResizeObserver(updateSize);
+	if (wrapRef.value) resizeObserver.observe(wrapRef.value);
+});
+
+onBeforeUnmount(() => {
+	if (resizeObserver) resizeObserver.disconnect();
+});
+</script>
+
+<template>
+	<div v-if="activeChart === 'SunburstChart'" ref="wrapRef" class="sunburstchart">
+		<div class="sunburstchart__svg-clip">
+			<svg :viewBox="`0 0 ${sunburstData.width} ${sunburstData.height}`" width="100%" height="100%">
+			<g>
+				<path
+					v-for="a in sunburstData.arcs"
+					:key="a.key"
+					:d="a.d"
+					class="sunburstchart__arc"
+					:fill="arcFill(a)"
+					:fill-opacity="arcOpacity(a)"
+					role="img"
+					:aria-label="a.title"
+					@mouseenter="(evt) => onArcHoverMove(evt, a)"
+					@mousemove="(evt) => onArcHoverMove(evt, a)"
+					@mouseleave="onArcHoverLeave"
+				/>
+			</g>
+			<g>
+				<text
+					v-for="t in sunburstData.labels"
+					:key="t.key"
+					:x="t.x"
+					:y="t.y"
+					class="sunburstchart__label"
+					text-anchor="middle"
+					dominant-baseline="middle"
+				>
+					{{ t.text }}
+				</text>
+			</g>
+		</svg>
+		</div>
+		<div
+			v-if="hoverTip.show"
+			class="sunburstchart__hover"
+			:class="{
+				'sunburstchart__hover--tl': hoverTip.placeLeft && hoverTip.placeAbove,
+				'sunburstchart__hover--tr': !hoverTip.placeLeft && hoverTip.placeAbove,
+				'sunburstchart__hover--bl': hoverTip.placeLeft && !hoverTip.placeAbove,
+				'sunburstchart__hover--br': !hoverTip.placeLeft && !hoverTip.placeAbove,
+			}"
+			:style="{ left: `${hoverTip.x}px`, top: `${hoverTip.y}px` }"
+		>
+			{{ hoverTip.text }}
+		</div>
+	</div>
+</template>
+
+<style scoped lang="scss">
+.sunburstchart {
+	width: 100%;
+	height: 100%;
+	position: relative;
+	overflow: visible;
+}
+
+/* 只裁切圖形；hover 用 fixed 畫在視窗上，不受父層 overflow 遮住 */
+.sunburstchart__svg-clip {
+	width: 100%;
+	height: 100%;
+	overflow: hidden;
+}
+
+.sunburstchart__label {
+	font-family: "微軟正黑體", "Microsoft JhengHei", "Droid Sans", "Open Sans",
+		"Helvetica", sans-serif;
+	font-size: 14px;
+	font-weight: 700;
+	fill: #e6edf5;
+	paint-order: stroke;
+	stroke: rgba(23, 28, 36, 0.42);
+	stroke-width: 1px;
+	pointer-events: none;
+}
+
+.sunburstchart__arc {
+	stroke: rgba(120, 120, 120, 0.65);
+	stroke-width: 1;
+	transition: fill 180ms ease, fill-opacity 180ms ease;
+}
+
+.sunburstchart__hover {
+	--tip-gap: 4px;
+	position: fixed;
+	margin: 0;
+	background: rgba(8, 11, 18, 0.92);
+	color: #fff;
+	font-family: "微軟正黑體", "Microsoft JhengHei", "Droid Sans", "Open Sans",
+		"Helvetica", sans-serif;
+	font-size: 14px;
+	font-weight: 700;
+	padding: 8px 12px;
+	border-radius: 6px;
+	border: 1px solid rgba(255, 255, 255, 0.2);
+	pointer-events: none;
+	white-space: normal;
+	word-break: break-word;
+	line-height: 1.4;
+	max-width: min(400px, calc(100vw - 20px));
+	z-index: 10050;
+	box-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
+	/* 錨在游標 (left/top)；translate 讓框緣距游標固定為 --tip-gap，左右象限對稱 */
+	&--tr {
+		transform: translate(var(--tip-gap), calc(-100% - var(--tip-gap)));
+	}
+	&--tl {
+		transform: translate(calc(-100% - var(--tip-gap)), calc(-100% - var(--tip-gap)));
+	}
+	&--br {
+		transform: translate(var(--tip-gap), var(--tip-gap));
+	}
+	&--bl {
+		transform: translate(calc(-100% - var(--tip-gap)), var(--tip-gap));
+	}
+}
+</style>

--- a/Taipei-City-Dashboard-FE/src/assets/configs/apexcharts/chartTypes.js
+++ b/Taipei-City-Dashboard-FE/src/assets/configs/apexcharts/chartTypes.js
@@ -19,6 +19,7 @@ export const chartTypes = {
 	IndicatorChart: "指標圖",
 	MapLegend: "地圖圖例",
 	TextUnitChart: "文字單位圖",
+	SunburstChart: "旭日圖",
 };
 
 export const chartsPerDataType = {
@@ -31,6 +32,7 @@ export const chartsPerDataType = {
 		"RadarChart",
 		"PolarAreaChart",
 		"MetroChart",
+		"SunburstChart",
 	],
 	three_d: [
 		"ColumnChart",

--- a/Taipei-City-Dashboard-FE/src/dashboardComponent/DashboardComponent.vue
+++ b/Taipei-City-Dashboard-FE/src/dashboardComponent/DashboardComponent.vue
@@ -28,6 +28,7 @@ import BarChartWithGoal from "./components/BarChartWithGoal.vue";
 import IconPercentChart from "./components/IconPercentChart.vue";
 import IndicatorChart from "./components/IndicatorChart.vue";
 import TextUnitChart from "./components/TextUnitChart.vue";
+import SunburstChart from "./components/SunburstChart.vue";
 
 import MapLegendSvg from "./assets/chart/MapLegend.svg";
 import DistrictChartSvg from "./assets/chart/DistrictChart.svg";
@@ -48,7 +49,7 @@ import BarChartWithGoalSvg from "./assets/chart/BarChartWithGoal.svg";
 import TreemapChartSvg from "./assets/chart/TreemapChart.svg";
 import IndicatorChartSvg from "./assets/chart/IndicatorChart.svg";
 import TextUnitChartSvg from "./assets/chart/TextUnitChart.svg";
-
+import SunburstChartSvg from "./assets/chart/SunburstChart.svg";
 
 const props = defineProps({
 	style: { type: Object, default: () => ({}) },
@@ -222,6 +223,8 @@ function returnChartComponent(name, svg) {
 		return svg ? IndicatorChartSvg : IndicatorChart;
 	case "TextUnitChart":
 		return svg ? TextUnitChartSvg : TextUnitChart;
+	case "SunburstChart":
+		return svg ? SunburstChartSvg : SunburstChart;
 	default:
 		return svg ? MapLegendSvg : MapLegend;
 	}

--- a/Taipei-City-Dashboard-FE/src/dashboardComponent/assets/chart/SunburstChart.svg
+++ b/Taipei-City-Dashboard-FE/src/dashboardComponent/assets/chart/SunburstChart.svg
@@ -1,0 +1,12 @@
+<svg width="220" height="140" viewBox="0 0 220 140" xmlns="http://www.w3.org/2000/svg">
+  <rect width="220" height="140" fill="#1f232a"/>
+  <g transform="translate(110,72)">
+    <path d="M0,-45 A45,45 0 0 1 42,0 L26,0 A29,29 0 0 0 0,-29 Z" fill="#4EA3FF"/>
+    <path d="M42,0 A45,45 0 0 1 0,45 L0,29 A29,29 0 0 0 26,0 Z" fill="#7ABEFF"/>
+    <path d="M0,45 A45,45 0 1 1 0,-45 L0,-29 A29,29 0 1 0 0,29 Z" fill="#F5A623"/>
+    <path d="M0,-70 A70,70 0 0 1 66,0 L50,0 A54,54 0 0 0 0,-54 Z" fill="#8BC7FF"/>
+    <path d="M66,0 A70,70 0 0 1 0,70 L0,54 A54,54 0 0 0 50,0 Z" fill="#A9D7FF"/>
+    <path d="M0,70 A70,70 0 1 1 0,-70 L0,-54 A54,54 0 1 0 0,54 Z" fill="#F8C164"/>
+    <circle r="18" fill="#1f232a"/>
+  </g>
+</svg>

--- a/Taipei-City-Dashboard-FE/src/dashboardComponent/utilities/chartTypes.ts
+++ b/Taipei-City-Dashboard-FE/src/dashboardComponent/utilities/chartTypes.ts
@@ -23,4 +23,5 @@ export const chartTypes: chartType = {
 	IndicatorChart: "指標圖", // V
 	MapLegend: "地圖圖例", // V
 	TextUnitChart: "文字數值圖", // V
+	SunburstChart: "旭日圖", // V
 };


### PR DESCRIPTION
# 旭日圖 功能 PR 說明

## 1. 功能名稱

旭日圖 SunburstChart

## 2. PR 連結

本PR

## 3. 相關程式異動清冊

### 前端異動檔路徑

#### `SunburstChart.vue`

新增旭日圖組件，將樹狀關係資料轉成旭日圖視覺，適合用來呈現多層級分類與占比關係。

主要功能包含：

- 依父子節點與數值建立旭日圖結構
- 支援多層級扇區顯示與分支配色
- 支援滑鼠 hover 顯示提示資訊
- 依圖表容器尺寸自動調整繪圖範圍
- 支援色彩自訂，並提供預設分支色
- 對不完整或空資料做基本容錯處理

#### `Taipei-City-Dashboard-FE/src/dashboardComponent/DashboardComponent.vue`

將 SunburstChart 加入 DashboardComponent 的圖表載入邏輯。

主要異動包含：

- import `SunburstChart.vue`
- 在 `returnChartComponent` 中新增 `SunburstChart` 對應
- 圖表縮圖改對應使用 `SunburstChart.svg`
- 讓 DashboardComponent 可正常切換與渲染旭日圖

### 後端異動檔路徑

無後端異動。

### 設定檔／圖表設定異動路徑

#### `Taipei-City-Dashboard-FE/src/assets/configs/apexcharts/chartTypes.js`

新增圖表型別：

- `SunburstChart: "旭日圖"`

並將 `SunburstChart` 加入一般資料型態可選圖表清單，使後台／設定端可選擇此圖表類型。

#### `Taipei-City-Dashboard-FE/src/dashboardComponent/utilities/chartTypes.ts`

新增前端圖表型別顯示名稱：

- `SunburstChart: "旭日圖"`

讓 dashboard component utilities 能正確辨識與顯示此圖表類型。

#### `Taipei-City-Dashboard-FE/src/dashboardComponent/assets/chart/SunburstChart.svg`

新增旭日圖圖示，供 DashboardComponent 顯示縮圖使用。

## 4. 測試方式與驗收重點

### 測試方式

1. 準備具備父子階層與數值的資料，將圖表型別設定為 `SunburstChart`。
2. 確認圖表能正常渲染，且層級關係能正確展開成旭日圖。
3. 檢查不同分支是否有清楚區分的顏色。
4. 將滑鼠移至扇區上，確認 tooltip 可正常顯示對應節點資訊與數值。
5. 調整圖表容器大小，確認旭日圖會依可用空間自適應。
6. 使用空資料或不完整資料測試，確認圖表不會報錯或畫面空白異常。
7. 切換到其他既有圖表型別，確認 `ColumnChart`、`BarChart`、`TreemapChart` 等原功能不受影響。

### 驗收重點

- `SunburstChart` 可作為新圖表型別被正確載入。
- 旭日圖可正確顯示多層級結構與占比關係。
- 滑鼠 hover 提示與圖表互動正常。
- 圖表縮圖與圖表型別名稱已正確註冊。
- 不影響既有圖表型別與 DashboardComponent 的切換邏輯。
