### PR TITLE
fix(eoc): URL 正式來源 + controller 修正(typo/排除測試/NULL/component-id)

### DIFF
--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/eoc_damage_case/eoc_damage_case.py
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/eoc_damage_case/eoc_damage_case.py
@@ -40,7 +40,7 @@ def _transfer(**kwargs):
     load_behavior = dag_infos.get('load_behavior')
     default_table = dag_infos.get('ready_data_default_table')
     history_table = dag_infos.get('ready_data_history_table')
-    URL = '''https://tfd.blob.core.windows.net/blobfs/data/TEST-T-SAGEDamageCaseData.json'''
+    URL = '''https://tfd.blob.core.windows.net/blobfs/data/T-SAGEDamageCaseData.json'''
 
     raw_data = requests.get(URL)
     raw_data_json = raw_data.json()

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/eoc_damage_case/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/eoc_damage_case/job_config.json
@@ -25,7 +25,7 @@
   "data_infos": {
     "name_cn": "EOC最新受損情形資料",
     "airflow_update_freq": "every 5 minutes",
-    "source": "https://tfd.blob.core.windows.net/blobfs/data/TEST-T-SAGEDamageCaseData.json",
+    "source": "https://tfd.blob.core.windows.net/blobfs/data/T-SAGEDamageCaseData.json",
     "source_type": "消防局 API",
     "source_dept": "消防局",
     "gis_format": "",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/eoc_dashboard_controller/eoc_dashboard_controller.py
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/eoc_dashboard_controller/eoc_dashboard_controller.py
@@ -33,22 +33,24 @@ def _transfer(**kwargs):
                     SELECT dp_name AS name
                     FROM eoc_damage_case_tpe
                     WHERE data_time >= NOW() - INTERVAL '24 hours'
-                    AND ABS(EXTRACT(EPOCH FROM (data_time - report_send_time)) / 86400) <= 5
+                    AND ABS(EXTRACT(EPOCH FROM (data_time - COALESCE(report_send_time, dp_issue_date_time, data_time))) / 86400) <= 5
+                    AND dp_name NOT ILIKE '%測試%' AND dp_name NOT ILIKE '%test%'
                     UNION ALL
                     SELECT dpname AS name
                     FROM eoc_disaster_summary_tpe
                     WHERE data_time >= NOW() - INTERVAL '24 hours'
-                    AND ABS(EXTRACT(EPOCH FROM (data_time - case_time)) / 86400) <= 5
+                    AND ABS(EXTRACT(EPOCH FROM (data_time - COALESCE(case_time, data_time))) / 86400) <= 5
+                    AND dpname NOT ILIKE '%測試%' AND dpname NOT ILIKE '%test%'
                 ) t
         """)
         unique_names = [row[0] for row in connection.execute(names_sql).fetchall()]
-        dashboard_hook = PostgresHook(postgres_conn_id="dashboad-postgre")
+        dashboard_hook = PostgresHook(postgres_conn_id="dashboard-postgre")
 
         # 無資料：刪除關聯並結束
         if not unique_names:
             try:
                 # 刪除所有 disaster_sus_*_% 相關的 component、query_charts、component_charts、dashboard、dashboard_groups
-                dashboard_hook = PostgresHook(postgres_conn_id="dashboad-postgre")
+                dashboard_hook = PostgresHook(postgres_conn_id="dashboard-postgre")
                 status_keys = ["disaster_sus_water", "disaster_sus_power", "disaster_sus_tel", "disaster_sus_gas"]
                 for status_key in status_keys:
                     like_pattern = f"{status_key}_%"
@@ -306,6 +308,10 @@ def _transfer(**kwargs):
                 print(f"dashboard {pname} 已存在，跳出並結束排程")
                 continue
 
+            max_comp_id_records = dashboard_hook.get_records('SELECT MAX(id) FROM public.components;')
+            current_max_comp_id = max_comp_id_records[0][0] if max_comp_id_records and max_comp_id_records[0][0] is not None else 999
+            next_comp_id = max(999, current_max_comp_id)
+
             # 建立 component，status_mapping key + _pname 為 component index, status_mapping['label'] + _pname 為 component name
             for status_key, status_val in status_mapping.items():
                 comp_index = f"{status_key}_{pname}"
@@ -315,9 +321,10 @@ def _transfer(**kwargs):
                     parameters={'index': comp_index}
                 )
                 if not recs:
+                    next_comp_id += 1
                     dashboard_hook.run(
-                        'INSERT INTO public.components ("index", name) VALUES (%(index)s, %(name)s);',
-                        parameters={'index': comp_index, 'name': comp_name}
+                        'INSERT INTO public.components ("id", "index", name) VALUES (%(id)s, %(index)s, %(name)s);',
+                        parameters={'id': next_comp_id, 'index': comp_index, 'name': comp_name}
                     )
                 recs = dashboard_hook.get_records(
                     'SELECT id FROM public.components WHERE "index" = %(index)s;',

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/eoc_disaster_summary/eoc_disaster_summary.py
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/eoc_disaster_summary/eoc_disaster_summary.py
@@ -36,7 +36,7 @@ def _transfer(**kwargs):
     load_behavior = dag_infos.get('load_behavior')
     default_table = dag_infos.get('ready_data_default_table')
     history_table = dag_infos.get('ready_data_history_table')
-    URL = '''https://tfd.blob.core.windows.net/blobfs/data/TEST-T-TSAGEDisasterSummary.json'''
+    URL = '''https://tfd.blob.core.windows.net/blobfs/data/T-SAGEDisasterSummary.json'''
     GEOMETRY_TYPE = "Point"   
     FROM_CRS = 4326
     raw_data = requests.get(URL)

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/eoc_disaster_summary/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/eoc_disaster_summary/job_config.json
@@ -24,7 +24,7 @@
   "data_infos": {
     "name_cn": "EOC最新災害專案災情資料",
     "airflow_update_freq": "every 5 minutes",
-    "source": "https://tfd.blob.core.windows.net/blobfs/data/TEST-T-TSAGEDisasterSummary.json",
+    "source": "https://tfd.blob.core.windows.net/blobfs/data/T-SAGEDisasterSummary.json",
     "source_type": "消防局 API",
     "source_dept": "消防局",
     "gis_format": "Point",


### PR DESCRIPTION
同 PR #1322,從 `origin/develop` 切出。cherry-pick 兩個 EOC 修正。

## 修正內容

### `eoc_damage_case` + `eoc_disaster_summary`
- 來源 URL **TEST- → 正式 TFD blob**
  - `T-SAGEDamageCaseData.json`
  - `T-SAGEDisasterSummary.json`
  - `.py` 與 `job_config.json` 同步

### `eoc_dashboard_controller`
- conn id typo: `dashboad-postgre` → `dashboard-postgre`
- dashboard 產生**排除測試災情**
- 時間差用 `COALESCE` 處理 NULL
- component INSERT 明確指定 `id`

## 前置條件
⚠️ 正式機需建 `dashboard-postgre` connection(指向 dashboardmanager DB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)