### PR TITLE
feat(dags): component_ai_summary DAG + multi-provider llm_provider util

### DIFF
--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/component_ai_summary/ai_summary_etl.py
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/component_ai_summary/ai_summary_etl.py
@@ -1,0 +1,185 @@
+import json
+
+from airflow.providers.postgres.hooks.postgres import PostgresHook
+from sqlalchemy import create_engine
+from sqlalchemy.sql import text as sa_text
+
+from utils.get_time import get_tpe_now_time
+from utils.llm_provider import generate_text
+
+# ponytail: 表名依 pkey constraint `component_ai_summaries_pkey` 推回(PG 預設命名 {table}_pkey)反推。
+# 若實際 table 是單數 component_ai_summary,改這裡即可。
+AI_SUMMARY_TABLE = "component_ai_summaries"
+
+CHART_SYSTEM_PROMPT = (
+    "你是台北市城市儀表板的資料助理。請根據提供的組件資訊,用繁體中文寫一段"
+    "100 到 150 字的摘要,說明這個圖表組件的用途、代表的指標意義,以及使用者可以如何解讀這份資料。"
+    "只需輸出摘要內容,不要條列、不要加標題。"
+)
+
+MAP_SYSTEM_PROMPT = (
+    "你是台北市城市儀表板的資料助理。請根據提供的地圖圖層資訊,用繁體中文寫一段"
+    "100 到 150 字的摘要,說明這個圖層呈現的空間資料內容、欄位意義,以及使用者可以從地圖上觀察到什麼。"
+    "只需輸出摘要內容,不要條列、不要加標題。"
+)
+
+
+def fetch_enabled_components(engine):
+    sql = sa_text(
+        """
+        SELECT index, city, short_desc, long_desc, use_case
+        FROM query_charts
+        WHERE enable_ai_summary IS TRUE
+        """
+    )
+    with engine.connect() as conn:
+        return [
+            {
+                "index": row[0],
+                "city": row[1],
+                "short_desc": row[2],
+                "long_desc": row[3],
+                "use_case": row[4],
+            }
+            for row in conn.execute(sql).fetchall()
+        ]
+
+
+def fetch_map_configs(engine, index, city):
+    """依 createTempComponentDB 同樣的 join 邏輯:query_charts.map_config_ids -> component_maps.id"""
+    sql = sa_text(
+        """
+        SELECT cm.index, cm.title, cm.type, cm.property
+        FROM query_charts qc
+        JOIN unnest(qc.map_config_ids) AS id_value ON true
+        JOIN component_maps cm ON cm.id = id_value
+        WHERE qc.index = :index AND qc.city = :city
+        """
+    )
+    with engine.connect() as conn:
+        return [
+            {"map_index": row[0], "title": row[1], "type": row[2], "property": row[3]}
+            for row in conn.execute(sql, {"index": index, "city": city}).fetchall()
+        ]
+
+
+def fetch_sql_view_info(geoserver_engine, view_name):
+    """向 GeoServer 掛的 postgres connection 直接 psql 拿 SQL View 欄位與定義。查不到就回 None,讓上層優雅跳過。"""
+    columns_sql = sa_text(
+        """
+        SELECT column_name
+        FROM information_schema.columns
+        WHERE table_name = :view_name
+        ORDER BY ordinal_position
+        """
+    )
+    viewdef_sql = sa_text(
+        "SELECT view_definition FROM information_schema.views WHERE table_name = :view_name"
+    )
+    with geoserver_engine.connect() as conn:
+        columns = [row[0] for row in conn.execute(columns_sql, {"view_name": view_name}).fetchall()]
+        viewdef_row = conn.execute(viewdef_sql, {"view_name": view_name}).fetchone()
+
+    if not columns:
+        return None
+    return {"columns": columns, "view_definition": viewdef_row[0] if viewdef_row else None}
+
+
+def build_chart_prompt(component):
+    return (
+        f"組件名稱(index):{component['index']}\n"
+        f"簡短說明:{component['short_desc'] or '無'}\n"
+        f"詳細說明:{component['long_desc'] or '無'}\n"
+        f"應用情境:{component['use_case'] or '無'}\n"
+    )
+
+
+def build_map_prompt(component, map_rows, sql_view_infos):
+    lines = [f"組件名稱(index):{component['index']}"]
+    for row in map_rows:
+        lines.append(f"\n圖層:{row['title']}(類型:{row['type']})")
+
+        # property 是 PG json 欄位,psycopg2 可能已自動解成 list,也可能是原始字串,兩種都要接
+        raw_property = row["property"]
+        if isinstance(raw_property, str):
+            try:
+                fields = json.loads(raw_property)
+            except ValueError:
+                fields = []
+        else:
+            fields = raw_property or []
+        if fields:
+            field_desc = "、".join(
+                f"{f.get('name')}({f.get('key')})" for f in fields if isinstance(f, dict)
+            )
+            lines.append(f"欄位說明:{field_desc}")
+
+        view_info = sql_view_infos.get(row["map_index"])
+        if view_info:
+            lines.append(f"資料庫欄位:{'、'.join(view_info['columns'])}")
+
+    return "\n".join(lines)
+
+
+def write_summary(engine, index, city, summary_type, result):
+    now = get_tpe_now_time(is_with_tz=True)
+    sql = sa_text(
+        f"""
+        INSERT INTO {AI_SUMMARY_TABLE} (index, city, type, result, created_at, updated_at)
+        VALUES (:index, :city, :type, :result, :now, :now)
+        """
+    )
+    with engine.begin() as conn:
+        conn.execute(
+            sql,
+            {"index": index, "city": city, "type": summary_type, "result": result, "now": now},
+        )
+
+
+def _get_geoserver_engine():
+    try:
+        return create_engine(PostgresHook(postgres_conn_id="geoserver-postgres").get_uri())
+    except Exception as e:
+        print(f"geoserver-postgres connection not available, skip SQL view lookup: {e}")
+        return None
+
+
+def ai_summary_etl(**kwargs):
+    dashboard_uri = PostgresHook(postgres_conn_id="dashboard-postgre").get_uri()
+    engine = create_engine(dashboard_uri)
+    geoserver_engine = _get_geoserver_engine()
+
+    components = fetch_enabled_components(engine)
+    print(f"Found {len(components)} components with enable_ai_summary = true.")
+
+    for component in components:
+        index, city = component["index"], component["city"]
+
+        try:
+            chart_summary = generate_text(CHART_SYSTEM_PROMPT, build_chart_prompt(component))
+            write_summary(engine, index, city, "chart", chart_summary)
+            print(f"[{index}/{city}] chart summary written.")
+        except Exception as e:
+            print(f"[{index}/{city}] chart summary failed: {e}")
+
+        map_rows = fetch_map_configs(engine, index, city)
+        if not map_rows:
+            continue
+
+        sql_view_infos = {}
+        if geoserver_engine is not None:
+            for row in map_rows:
+                try:
+                    info = fetch_sql_view_info(geoserver_engine, row["map_index"])
+                    if info:
+                        sql_view_infos[row["map_index"]] = info
+                except Exception as e:
+                    print(f"[{index}/{city}] SQL view lookup failed for {row['map_index']}: {e}")
+
+        try:
+            map_prompt = build_map_prompt(component, map_rows, sql_view_infos)
+            map_summary = generate_text(MAP_SYSTEM_PROMPT, map_prompt)
+            write_summary(engine, index, city, "map", map_summary)
+            print(f"[{index}/{city}] map summary written.")
+        except Exception as e:
+            print(f"[{index}/{city}] map summary failed: {e}")

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/component_ai_summary/ai_summary_etl.py
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/component_ai_summary/ai_summary_etl.py
@@ -7,9 +7,7 @@ from sqlalchemy.sql import text as sa_text
 from utils.get_time import get_tpe_now_time
 from utils.llm_provider import generate_text
 
-# ponytail: 表名依 pkey constraint `component_ai_summaries_pkey` 推回(PG 預設命名 {table}_pkey)反推。
-# 若實際 table 是單數 component_ai_summary,改這裡即可。
-AI_SUMMARY_TABLE = "component_ai_summaries"
+AI_SUMMARY_TABLE = "component_ai_summary"
 
 CHART_SYSTEM_PROMPT = (
     "你是台北市城市儀表板的資料助理。請根據提供的組件資訊,用繁體中文寫一段"
@@ -63,8 +61,40 @@ def fetch_map_configs(engine, index, city):
         ]
 
 
-def fetch_sql_view_info(geoserver_engine, view_name):
-    """向 GeoServer 掛的 postgres connection 直接 psql 拿 SQL View 欄位與定義。查不到就回 None,讓上層優雅跳過。"""
+def fetch_sql_view_info(catalog_engine, geodata_engine, view_name):
+    """
+    圖層在 GeoServer 分兩種:
+    1. SQL View(JDBC_VIRTUAL_TABLE):真正的查詢語法(可能是 join/聚合)存在 GeoServer 自己的
+       catalog(pgconfig.resourceinfo.info.metadata.MetadataMap.JDBC_VIRTUAL_TABLE...sql),
+       不是 dashboard-stream 裡的實體物件,要先查這裡。
+    2. 純資料表:GeoServer 直接對應 dashboard-stream 的一張表,沒有 JDBC_VIRTUAL_TABLE,
+       退回查 information_schema.columns 拿欄位清單。
+    兩邊都查不到就回 None,讓上層優雅跳過。
+    """
+    if catalog_engine is not None:
+        try:
+            with catalog_engine.connect() as conn:
+                row = conn.execute(
+                    sa_text("SELECT info FROM pgconfig.resourceinfo WHERE name = :name"),
+                    {"name": view_name},
+                ).fetchone()
+            if row and row[0]:
+                vt = (
+                    row[0].get("metadata", {})
+                    .get("MetadataMap", {})
+                    .get("JDBC_VIRTUAL_TABLE", {})
+                    .get("Literal", {})
+                    .get("value", {})
+                )
+                sql_query = vt.get("sql")
+                if sql_query:
+                    return {"sql_query": sql_query.strip(), "columns": None}
+        except Exception as e:
+            print(f"GeoServer catalog lookup failed for {view_name}: {e}")
+
+    if geodata_engine is None:
+        return None
+
     columns_sql = sa_text(
         """
         SELECT column_name
@@ -73,16 +103,12 @@ def fetch_sql_view_info(geoserver_engine, view_name):
         ORDER BY ordinal_position
         """
     )
-    viewdef_sql = sa_text(
-        "SELECT view_definition FROM information_schema.views WHERE table_name = :view_name"
-    )
-    with geoserver_engine.connect() as conn:
+    with geodata_engine.connect() as conn:
         columns = [row[0] for row in conn.execute(columns_sql, {"view_name": view_name}).fetchall()]
-        viewdef_row = conn.execute(viewdef_sql, {"view_name": view_name}).fetchone()
 
     if not columns:
         return None
-    return {"columns": columns, "view_definition": viewdef_row[0] if viewdef_row else None}
+    return {"sql_query": None, "columns": columns}
 
 
 def build_chart_prompt(component):
@@ -116,7 +142,10 @@ def build_map_prompt(component, map_rows, sql_view_infos):
 
         view_info = sql_view_infos.get(row["map_index"])
         if view_info:
-            lines.append(f"資料庫欄位:{'、'.join(view_info['columns'])}")
+            if view_info["sql_query"]:
+                lines.append(f"圖層 SQL 查詢邏輯:{view_info['sql_query']}")
+            elif view_info["columns"]:
+                lines.append(f"資料庫欄位:{'、'.join(view_info['columns'])}")
 
     return "\n".join(lines)
 
@@ -136,18 +165,38 @@ def write_summary(engine, index, city, summary_type, result):
         )
 
 
-def _get_geoserver_engine():
+# ponytail: geoserver-postgres 接的 db(geoserver_pgconfig)是 GeoServer 自己的 pgconfig
+# catalog(workspace/layer/store 設定 + SQL View 查詢語法都存在這裡的 jsonb 欄位)。實際圖層
+# 資料表(非 SQL View 的 fallback 用)則在同一台 Postgres 的 dashboard-stream db、schema
+# public(實測這個部署唯一的 PostGIS store 就是指向它)。所以 catalog 用原本連線,geodata 借
+# 用同一組帳密把 dbname 換掉即可,不用另外設 connection。之後如果 GeoServer 掛了不只一個
+# store,要改成真的走 pgconfig.storeinfo 查每個 layer 對應的 store db,而不是寫死。
+GEODATA_DBNAME = "dashboard-stream"
+
+
+def _get_geoserver_catalog_engine():
     try:
         return create_engine(PostgresHook(postgres_conn_id="geoserver-postgres").get_uri())
     except Exception as e:
-        print(f"geoserver-postgres connection not available, skip SQL view lookup: {e}")
+        print(f"geoserver-postgres connection not available, skip GeoServer catalog lookup: {e}")
+        return None
+
+
+def _get_geodata_engine():
+    try:
+        conn = PostgresHook(postgres_conn_id="geoserver-postgres").get_connection("geoserver-postgres")
+        uri = f"postgresql://{conn.login}:{conn.password}@{conn.host}:{conn.port}/{GEODATA_DBNAME}"
+        return create_engine(uri)
+    except Exception as e:
+        print(f"geoserver-postgres connection not available, skip geodata table lookup: {e}")
         return None
 
 
 def ai_summary_etl(**kwargs):
     dashboard_uri = PostgresHook(postgres_conn_id="dashboard-postgre").get_uri()
     engine = create_engine(dashboard_uri)
-    geoserver_engine = _get_geoserver_engine()
+    catalog_engine = _get_geoserver_catalog_engine()
+    geodata_engine = _get_geodata_engine()
 
     components = fetch_enabled_components(engine)
     print(f"Found {len(components)} components with enable_ai_summary = true.")
@@ -167,10 +216,10 @@ def ai_summary_etl(**kwargs):
             continue
 
         sql_view_infos = {}
-        if geoserver_engine is not None:
+        if catalog_engine is not None or geodata_engine is not None:
             for row in map_rows:
                 try:
-                    info = fetch_sql_view_info(geoserver_engine, row["map_index"])
+                    info = fetch_sql_view_info(catalog_engine, geodata_engine, row["map_index"])
                     if info:
                         sql_view_infos[row["map_index"]] = info
                 except Exception as e:

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/component_ai_summary/component_ai_summary.py
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/component_ai_summary/component_ai_summary.py
@@ -1,0 +1,11 @@
+from airflow import DAG
+from operators.common_pipeline import CommonDag
+from proj_city_dashboard.component_ai_summary.ai_summary_etl import ai_summary_etl
+
+
+def component_ai_summary(**kwargs):
+    ai_summary_etl(**kwargs)
+
+
+dag = CommonDag(proj_folder="proj_city_dashboard", dag_folder="component_ai_summary")
+dag.create_dag(etl_func=component_ai_summary)

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/component_ai_summary/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/component_ai_summary/job_config.json
@@ -1,0 +1,37 @@
+{
+  "dag_infos": {
+    "dag_id": "component_ai_summary",
+    "start_date": "2026-07-07",
+    "schedule_interval": "0 20 * * *",
+    "catchup": false,
+    "tags": ["component_ai_summary", "AI", "台北市", "Taipei-City", "組件摘要"],
+    "description": "掃描 query_charts 已啟用 AI 摘要的組件,產製圖表摘要與地圖圖層摘要,寫入 component_ai_summaries",
+    "default_args": {
+      "owner": "airflow",
+      "email": ["DEFAULT_EMAIL_LIST"],
+      "email_on_retry": false,
+      "email_on_failure": true,
+      "retries": 1,
+      "retry_delay": 60
+    },
+    "ready_data_db": "postgres_default",
+    "ready_data_default_table": "",
+    "ready_data_history_table": "",
+    "raw_data_db": "postgres_default",
+    "raw_data_table": "",
+    "load_behavior": "replace"
+  },
+  "data_infos": {
+    "name_cn": "組件 AI 摘要",
+    "airflow_update_freq": "@daily",
+    "source": "",
+    "source_type": "",
+    "source_dept": "",
+    "gis_format": "",
+    "output_coordinate": "",
+    "is_geometry": 0,
+    "dataset_description": "儀表板組件圖表與地圖圖層的 AI 摘要",
+    "etl_description": "讀取 query_charts + component_maps,呼叫 TWCC 產生摘要,寫入 component_ai_summaries",
+    "sensitivity": "public"
+  }
+}

--- a/Taipei-City-Dashboard-DE/dags/utils/llm_provider.py
+++ b/Taipei-City-Dashboard-DE/dags/utils/llm_provider.py
@@ -1,0 +1,144 @@
+"""
+Generic multi-provider LLM text generation for DAGs.
+
+This project's own deployment defaults to TWCC (Taiwan's national AI cloud service,
+gov-only access) — but that's not something a clone of this open-source repo can use.
+Self-hosters should set the Airflow Variable `LLM_PROVIDER` to "openai" or "gemini"
+instead and fill in that provider's own `*_API_KEYS` Variable; every call site in the
+DAGs just calls `generate_text()` and doesn't care which backend is behind it.
+
+Required Airflow Variables (only the ones for your chosen LLM_PROVIDER):
+    TWCC_API_KEYS / OPENAI_API_KEYS / GEMINI_API_KEYS
+        A single key string, or a JSON/Python list of keys to rotate through if one
+        fails or gets rate-limited, e.g. '["key1","key2"]'.
+    TWCC_API_URL, TWCC_MODEL / OPENAI_API_URL, OPENAI_MODEL / GEMINI_API_URL, GEMINI_MODEL
+        Optional overrides; each has a sane default below.
+"""
+from ast import literal_eval
+
+import requests
+from airflow.models import Variable
+
+DEFAULT_PROVIDER = "twcc"
+
+_DEFAULTS = {
+    "twcc": {"api_url": "https://api-ams.twcc.ai/api", "model": "llama3.3-ffm-70b-32k-chat"},
+    "openai": {"api_url": "https://api.openai.com/v1", "model": "gpt-4o"},
+    "gemini": {"api_url": "https://generativelanguage.googleapis.com", "model": "gemini-1.5-pro"},
+}
+
+
+def _get_api_keys(variable_name):
+    raw = Variable.get(variable_name)
+    keys = literal_eval(raw) if raw.strip().startswith("[") else [raw]
+    return [k for k in keys if k]
+
+
+def _with_key_rotation(provider_label, api_keys, send_request):
+    last_error = None
+    for api_key in api_keys:
+        try:
+            return send_request(api_key)
+        except Exception as e:
+            last_error = e
+            print(f"{provider_label} key ...{api_key[-4:]} failed, rotating to next key: {e}")
+    raise RuntimeError(f"All {provider_label} API keys failed: {last_error}")
+
+
+def _call_twcc(system_prompt, user_prompt, max_tokens, temperature):
+    api_keys = _get_api_keys("TWCC_API_KEYS")
+    base_url = Variable.get("TWCC_API_URL", _DEFAULTS["twcc"]["api_url"])
+    model = Variable.get("TWCC_MODEL", _DEFAULTS["twcc"]["model"])
+
+    body = {
+        "model": model,
+        "messages": [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt},
+        ],
+        "parameters": {"max_new_tokens": max_tokens, "temperature": temperature},
+        "stream": False,
+    }
+
+    def send(api_key):
+        resp = requests.post(
+            f"{base_url}/models/conversation",
+            json=body,
+            headers={"Content-Type": "application/json", "X-API-KEY": api_key},
+            timeout=60,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        content = data.get("generated_text")
+        if not content and data.get("choices"):
+            content = data["choices"][0]["message"]["content"]
+        return content.strip()
+
+    return _with_key_rotation("TWCC", api_keys, send)
+
+
+def _call_openai(system_prompt, user_prompt, max_tokens, temperature):
+    api_keys = _get_api_keys("OPENAI_API_KEYS")
+    base_url = Variable.get("OPENAI_API_URL", _DEFAULTS["openai"]["api_url"])
+    model = Variable.get("OPENAI_MODEL", _DEFAULTS["openai"]["model"])
+
+    body = {
+        "model": model,
+        "messages": [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt},
+        ],
+        "max_tokens": max_tokens,
+        "temperature": temperature,
+    }
+
+    def send(api_key):
+        resp = requests.post(
+            f"{base_url}/chat/completions",
+            json=body,
+            headers={"Content-Type": "application/json", "Authorization": f"Bearer {api_key}"},
+            timeout=60,
+        )
+        resp.raise_for_status()
+        return resp.json()["choices"][0]["message"]["content"].strip()
+
+    return _with_key_rotation("OpenAI", api_keys, send)
+
+
+def _call_gemini(system_prompt, user_prompt, max_tokens, temperature):
+    api_keys = _get_api_keys("GEMINI_API_KEYS")
+    base_url = Variable.get("GEMINI_API_URL", _DEFAULTS["gemini"]["api_url"])
+    model = Variable.get("GEMINI_MODEL", _DEFAULTS["gemini"]["model"])
+
+    body = {
+        "contents": [{"role": "user", "parts": [{"text": user_prompt}]}],
+        "systemInstruction": {"parts": [{"text": system_prompt}]},
+        "generationConfig": {"maxOutputTokens": max_tokens, "temperature": temperature},
+    }
+
+    def send(api_key):
+        resp = requests.post(
+            f"{base_url}/v1beta/models/{model}:generateContent?key={api_key}",
+            json=body,
+            headers={"Content-Type": "application/json"},
+            timeout=60,
+        )
+        resp.raise_for_status()
+        return resp.json()["candidates"][0]["content"]["parts"][0]["text"].strip()
+
+    return _with_key_rotation("Gemini", api_keys, send)
+
+
+_PROVIDERS = {
+    "twcc": _call_twcc,
+    "openai": _call_openai,
+    "gemini": _call_gemini,
+}
+
+
+def generate_text(system_prompt, user_prompt, max_tokens=600, temperature=0.3):
+    """Generate text via whichever provider the `LLM_PROVIDER` Airflow Variable selects."""
+    provider = Variable.get("LLM_PROVIDER", DEFAULT_PROVIDER)
+    if provider not in _PROVIDERS:
+        raise ValueError(f"Unknown LLM_PROVIDER '{provider}'. Supported: {list(_PROVIDERS)}")
+    return _PROVIDERS[provider](system_prompt, user_prompt, max_tokens, temperature)


### PR DESCRIPTION
## Summary
- 新增 `component_ai_summary` DAG:每天掃 `query_charts.enable_ai_summary`,用 `long_desc`/`use_case` 產出圖表摘要;並依 `map_config_ids` 關聯 `component_maps`(+ 選配的 `geoserver-postgres` connection 查 GeoServer catalog 取得 SQL View 查詢邏輯,查不到再退回 `dashboard-stream` 的實體資料表欄位)產出地圖圖層摘要,寫入 `component_ai_summary`。
- 新增 `utils/llm_provider.py`:通用多 LLM provider(`twcc`/`openai`/`gemini`),透過 Airflow Variable `LLM_PROVIDER` 切換,預設 `twcc`(本專案部署用);self-host 的人可換成 `openai`/`gemini`,不需要台灣公部門雲端存取權,API key 支援多組輪播。

這個 PR cherry-pick 自 #1339(對 `feature/airflow-3-upgrade` 發的版本),因為那條分支跟 `develop` 歷史差太多、直接發 MR 會夾帶大量無關 commit,所以改成從乾淨的 `origin/develop` 切分支、只帶這兩個 commit 過來。程式碼跟 #1339 完全一致,已經是實測跑通的版本。

## 已在 SIT(167.105.121.178)實測驗證
- `airflow dags test` 針對 236 個組件跑過全量批次(chart + map 摘要),資料正確寫入 `component_ai_summary`
- 驗證過純資料表 fallback 路徑(如 `bike_network`)與 GeoServer SQL View catalog 路徑(如 `youbike_availability`,含 join/聚合的 virtual table 查詢邏輯)兩種情境都正確運作
- 測試用的 `enable_ai_summary` 旗標與相關測試資料已在 SIT 上清理/處理完畢

## 部署前需設定(Airflow UI)
**Variables:**
- `TWCC_API_KEYS`(或選用 provider 對應的 `OPENAI_API_KEYS`/`GEMINI_API_KEYS`):單一 key 字串,或 JSON list 供輪播,如 `["key1","key2"]`
- `LLM_PROVIDER`(選填,預設 `twcc`)

**Connection(選配):**
- `geoserver-postgres`:接 GeoServer 的 pgconfig catalog db(存 workspace/layer/SQL View 設定),host/帳密與 `dashboard-postgre` 相同,只是 dbname 換成 GeoServer 的 pgconfig db。沒設也不會壞,程式會 catch 連線失敗、跳過這段,圖層摘要照樣用 `component_maps` 現有欄位產出。

## 待確認的假設
- 圖層對應 GeoServer catalog 時,用 `component_maps.index` 當 layer name 去查 `pgconfig.resourceinfo`;若命名規則不同,改 `ai_summary_etl.py` 的 `fetch_sql_view_info` 呼叫處傳入的 key 即可。
- 目前這個部署只有一個 PostGIS store(全部指向同一個 geodata db),`GEODATA_DBNAME` 是寫死的常數;若之後 GeoServer 掛了不只一個 store,要改成真的查 `pgconfig.storeinfo` 找每個 layer 對應的 store db。

🤖 Generated with [Claude Code](https://claude.com/claude-code)