### PR TITLE
fix(rental_subsidy_application_status): 拆分 112-113 合併年度為逐年資料

### DIFF
--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/rental_subsidy_application_status/rental_subsidy_application_status.py
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/rental_subsidy_application_status/rental_subsidy_application_status.py
@@ -20,6 +20,8 @@ def _ensure_ready_table(engine, table_name, col_map):
 
 
 def _rental_subsidy_application_status(**kwargs):
+    import re
+
     import pandas as pd
     from sqlalchemy import create_engine
     from utils.extract_stage import get_current_rid_from_page_id, get_data_taipei_api
@@ -75,9 +77,39 @@ def _rental_subsidy_application_status(**kwargs):
             "租金補貼核定戶數": "approved_households",
         }
     )
+    # 來源自 112 年度起將兩個年度合併為一筆(如「112-113年度」),數值為兩年合計,
+    # 計畫戶數僅寫「見備註」。依備註「申請戶數計N戶，核准戶數計N戶」的合計數字
+    # 平分拆回逐年(餘數給後一年,兩年加總不變)。
+    # ponytail: 備註僅有兩年合計、無逐年官方數,平分為近似值;若來源日後改回
+    # 逐年列(如「112年度」),不會命中此 regex,會原樣通過。
+    # 自 111 年度起租金補貼改由中央三百億方案受理,無臺北市計畫戶數,故留空。
+    combo = data["year"].astype("string").str.extract(r"^(\d+)-(\d+)年度$")
+    combo_mask = combo[0].notna()
+    split_rows = []
+    for idx in data.index[combo_mask]:
+        y1, y2 = int(combo.loc[idx, 0]), int(combo.loc[idx, 1])
+        m = re.search(
+            r"申請戶數計([\d,]+)戶，核准戶數計([\d,]+)戶", str(data.loc[idx, "備註"])
+        )
+        if y2 != y1 + 1 or not m:
+            continue  # 拆不出來寧可整筆略過,也不寫入錯的數字
+        applied, approved = (int(g.replace(",", "")) for g in m.groups())
+        for year, app, appr in (
+            (y1, applied // 2, approved // 2),
+            (y2, applied - applied // 2, approved - approved // 2),
+        ):
+            split_rows.append(
+                {
+                    "year": f"{year}年度",
+                    "application_households": app,
+                    "planned_households": None,
+                    "approved_households": appr,
+                }
+            )
+    data = pd.concat([data[~combo_mask], pd.DataFrame(split_rows)], ignore_index=True)
     data["city"] = "臺北市"
     data["year"] = _to_ad_year(data["year"])
-    data = data[data["year"] <= 2021]
+    data = data[data["year"].notna()]
 
     # === Normalize ===
     for col in ["application_households", "planned_households", "approved_households"]:

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/rental_subsidy_application_status/test_rental_subsidy_application_status.py
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/rental_subsidy_application_status/test_rental_subsidy_application_status.py
@@ -10,6 +10,7 @@ Run from DAG folder:
 from __future__ import annotations
 
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -28,7 +29,8 @@ TAIPEI_RID = "e54950a4-86b4-407b-bccf-180f17e1b310"
 
 def _fetch_data_taipei(rid: str) -> list[dict]:
     url = f"https://data.taipei/api/v1/dataset/{rid}?scope=resourceAquire&limit=2"
-    res = requests.get(url, timeout=30)
+    # data.taipei 憑證缺 Subject Key Identifier,新版 OpenSSL 驗證會失敗;DAG utils 同樣 verify=False
+    res = requests.get(url, timeout=30, verify=False)
     res.raise_for_status()
     body = res.json()
     records = (body.get("result") or {}).get("results") or []
@@ -48,9 +50,24 @@ def test_source_url_reachable():
     print(f"  data.taipei reachable, keys: {list(taipei_records[0].keys())[:8]}")
 
 
+def test_combined_year_remark_parsable():
+    """合併年度列（如「112-113年度」）的備註必須含 DAG 拆分邏輯依賴的合計數字。"""
+    url = f"https://data.taipei/api/v1/dataset/{TAIPEI_RID}?scope=resourceAquire&limit=1000"
+    res = requests.get(url, timeout=30, verify=False)
+    res.raise_for_status()
+    records = (res.json().get("result") or {}).get("results") or []
+    combined = [r for r in records if re.match(r"^\d+-\d+年度$", str(r.get("項目", "")))]
+    for row in combined:
+        remark = str(row.get("備註", ""))
+        if not re.search(r"申請戶數計([\d,]+)戶，核准戶數計([\d,]+)戶", remark):
+            raise AssertionError(f"合併年度列備註無法解析: {row.get('項目')}: {remark[:80]}")
+    print(f"  combined-year rows: {len(combined)}, remarks parsable")
+
+
 if __name__ == "__main__":
     try:
         test_source_url_reachable()
+        test_combined_year_remark_parsable()
     except Exception as e:
         print(f"FAIL [{TABLE_NAME}]: {e}", file=sys.stderr)
         sys.exit(1)


### PR DESCRIPTION
## 問題

資料來源「臺北市歷年住宅補貼受理情形統計表」最新一筆的「項目」欄位為 **112-113年度**(兩年合併),數值為兩年合計,且「租金補貼計畫戶數」僅寫「見備註」。原 DAG 以 `year <= 2021` 直接截斷,111 年度之後全部進不了 ready table。

## 做法

- 以 regex 比對 `^\d+-\d+年度$` 的合併年度列,解析備註「申請戶數計95,553戶，核准戶數計79,759戶」的合計數字,**平分拆回 112、113 年度**(餘數給後一年,兩年加總不變)。
- 計畫戶數:111 年度起租金補貼改由中央「三百億元擴大租金補貼」受理,無臺北市計畫戶數配額,故留 NULL(來源即「見備註」)。
- 移除 `year <= 2021` 截斷,111 年度(申請 42,546/核定 35,274)一併輸出;改為過濾無效年度列。
- 測試:新增「合併年度列備註必須可解析」的來源契約檢查;兩處 fetch 比照 river_channel 等測試補 `verify=False`(data.taipei 憑證缺 Subject Key Identifier,新版 OpenSSL 會驗證失敗)。
- job_config 不動:合併年度列可能為來源特例,不確定未來是否改回逐年,etl_description 維持原文。

## 拆分結果(以來源實際資料驗證,總和不變)

| year | application | planned | approved |
|---|---|---|---|
| 2022 (111年度) | 42,546 | NULL | 35,274 |
| 2023 (112年度) | 47,776 | NULL | 39,879 |
| 2024 (113年度) | 47,777 | NULL | 39,880 |

112+113 加總 = 95,553 / 79,759,與備註合計一致。`test_rental_subsidy_application_status.py` 全數通過。

## 注意事項

- **平分為近似值**:備註只有兩年合計、無逐年官方數字,故採平分(sum-preserving)。若日後來源改回逐年列(如「112年度」),不會命中拆分 regex,原樣通過。
- **加碼補貼(受理 3,595/核准 2,084)未計入**:其對象為三百億方案核准戶(子集),計入會重複計算;與 111 年度列的欄位口徑一致。
- **分支基底**:原需求指定從 `develop-etl` 切分支,但此 DAG 不存在於 `develop-etl`(僅存在於 `feature/airflow-3-upgrade`/`sit`),故改由 PR 目標 `feature/airflow-3-upgrade` 切出。
- purchase/repair 兩個 DAG 的同項修正在後續 PR 處理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)