### PR TITLE
fix(component_ai_summary): 重新生成時蓋掉舊摘要

### DIFF
--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/component_ai_summary/ai_summary_etl.py
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/component_ai_summary/ai_summary_etl.py
@@ -379,16 +379,26 @@ def build_map_prompt(component, map_rows, map_query_infos):
 
 
 def write_summary(engine, index, city, summary_type, result):
+    """
+    蓋掉舊的:同一組 (index, city, type) 只留最新一筆,不再 append-only 累積歷史列。
+    表沒有 unique constraint 可以用 ON CONFLICT,改成同一個 transaction 內先刪舊的
+    再插新的(READ COMMITTED 下外部讀到的要嘛是舊列要嘛是新列,不會看到中間空窗)。
+    """
     now = get_tpe_now_time(is_with_tz=True)
-    sql = sa_text(
-        f"""
-        INSERT INTO {AI_SUMMARY_TABLE} (index, city, type, result, created_at, updated_at)
-        VALUES (:index, :city, :type, :result, :now, :now)
-        """
-    )
     with engine.begin() as conn:
         conn.execute(
-            sql,
+            sa_text(
+                f"DELETE FROM {AI_SUMMARY_TABLE} WHERE index = :index AND city = :city AND type = :type"
+            ),
+            {"index": index, "city": city, "type": summary_type},
+        )
+        conn.execute(
+            sa_text(
+                f"""
+                INSERT INTO {AI_SUMMARY_TABLE} (index, city, type, result, created_at, updated_at)
+                VALUES (:index, :city, :type, :result, :now, :now)
+                """
+            ),
             {"index": index, "city": city, "type": summary_type, "result": result, "now": now},
         )
 


### PR DESCRIPTION
## Summary
原本 `write_summary` 每次都是 INSERT，同一組 `(index, city, type)` 重複重新生成會一直加新列，永遠留著舊的。這會導致「重新生成後看到舊內容」的混淆——如果撈資料的地方沒有明確 `ORDER BY updated_at DESC`，拿到的可能是任何一筆歷史列，不保證是最新的。

改成同一個 transaction 內先 `DELETE` 該 `(index, city, type)` 的所有列，再 `INSERT` 一筆新的。表沒有 unique constraint 能用 `ON CONFLICT`，所以用 DELETE+INSERT 達到等效的「蓋掉」效果；READ COMMITTED 隔離層級下不會看到中間的空窗期。

## 已在 SIT 實測
`bike_network/taipei/map` 原本累積了 28 筆歷史紀錄（這次開發反覆測試留下的），觸發一次後收斂成 **1 筆**，新內容正確保留顏色色碼。

🤖 Generated with [Claude Code](https://claude.com/claude-code)