### PR TITLE
fix(purchase/repair_subsidy_application_status): 拆分 112-113 合併年度為逐年

### DIFF
--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/purchase_subsidy_application_status/purchase_subsidy_application_status.py
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/purchase_subsidy_application_status/purchase_subsidy_application_status.py
@@ -75,9 +75,37 @@ def _purchase_subsidy_application_status(**kwargs):
             "自購住宅貸款利息補貼核定戶數": "approved_households",
         }
     )
+    # 來源自 112 年度起將兩個年度合併為一筆(如「112-113年度」),欄位數值皆為兩年合計。
+    # 平分拆回逐年(餘數給後一年,兩年加總不變);非數值(如「見備註」)無從拆分,留空。
+    # ponytail: 備註僅有租金補貼數字,本 DAG 以欄位合計平分為近似值;若來源日後改回
+    # 逐年列(如「112年度」),不會命中此 regex,會原樣通過。
+    combo = data["year"].astype("string").str.extract(r"^(\d+)-(\d+)年度$")
+    combo_mask = combo[0].notna()
+    split_rows = []
+    for idx in data.index[combo_mask]:
+        y1, y2 = int(combo.loc[idx, 0]), int(combo.loc[idx, 1])
+        if y2 != y1 + 1:
+            continue  # 非連續兩年拆不了,寧可整筆略過,也不寫入錯的數字
+        first, second = {"year": f"{y1}年度"}, {"year": f"{y2}年度"}
+        for col in [
+            "application_households",
+            "planned_households",
+            "approved_households",
+        ]:
+            total = pd.to_numeric(
+                str(data.loc[idx, col]).replace(",", ""), errors="coerce"
+            )
+            if pd.isna(total):
+                first[col] = second[col] = None
+            else:
+                first[col] = int(total) // 2
+                second[col] = int(total) - int(total) // 2
+        split_rows.append(first)
+        split_rows.append(second)
+    data = pd.concat([data[~combo_mask], pd.DataFrame(split_rows)], ignore_index=True)
     data["city"] = "臺北市"
     data["year"] = _to_ad_year(data["year"])
-    data = data[data["year"] <= 2022]
+    data = data[data["year"].notna()]
 
     # === Normalize ===
     for col in [

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/purchase_subsidy_application_status/test_purchase_subsidy_application_status.py
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/purchase_subsidy_application_status/test_purchase_subsidy_application_status.py
@@ -10,6 +10,7 @@ Run from DAG folder:
 from __future__ import annotations
 
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -28,7 +29,8 @@ TAIPEI_RID = "e54950a4-86b4-407b-bccf-180f17e1b310"
 
 def _fetch_data_taipei(rid: str) -> list[dict]:
     url = f"https://data.taipei/api/v1/dataset/{rid}?scope=resourceAquire&limit=2"
-    res = requests.get(url, timeout=30)
+    # data.taipei 憑證缺 Subject Key Identifier,新版 OpenSSL 驗證會失敗;DAG utils 同樣 verify=False
+    res = requests.get(url, timeout=30, verify=False)
     res.raise_for_status()
     body = res.json()
     records = (body.get("result") or {}).get("results") or []
@@ -53,9 +55,31 @@ def test_source_url_reachable():
     print(f"  data.taipei reachable, keys: {list(taipei_records[0].keys())[:10]}")
 
 
+def test_combined_year_row_values_numeric():
+    """合併年度列（如「112-113年度」）的補貼欄位須為數字，拆分邏輯才有依據。"""
+    url = f"https://data.taipei/api/v1/dataset/{TAIPEI_RID}?scope=resourceAquire&limit=1000"
+    res = requests.get(url, timeout=30, verify=False)
+    res.raise_for_status()
+    records = (res.json().get("result") or {}).get("results") or []
+    combined = [r for r in records if re.match(r"^\d+-\d+年度$", str(r.get("項目", "")))]
+    for row in combined:
+        for col in (
+            "自購住宅貸款利息補貼申請戶數",
+            "自購住宅貸款利息補貼計畫戶數",
+            "自購住宅貸款利息補貼核定戶數",
+        ):
+            value = str(row.get(col, "")).replace(",", "").strip()
+            if not value.isdigit():
+                raise AssertionError(
+                    f"合併年度列 {row.get('項目')} 欄位非數字: {col}={row.get(col)}"
+                )
+    print(f"  combined-year rows: {len(combined)}, values numeric")
+
+
 if __name__ == "__main__":
     try:
         test_source_url_reachable()
+        test_combined_year_row_values_numeric()
     except Exception as e:
         print(f"FAIL [{TABLE_NAME}]: {e}", file=sys.stderr)
         sys.exit(1)

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/repair_subsidy_application_status/repair_subsidy_application_status.py
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/repair_subsidy_application_status/repair_subsidy_application_status.py
@@ -75,9 +75,37 @@ def _repair_subsidy_application_status(**kwargs):
             "修繕住宅貸款利息補貼核定戶數": "approved_households",
         }
     )
+    # 來源自 112 年度起將兩個年度合併為一筆(如「112-113年度」),欄位數值皆為兩年合計。
+    # 平分拆回逐年(餘數給後一年,兩年加總不變);非數值(如「見備註」)無從拆分,留空。
+    # ponytail: 備註僅有租金補貼數字,本 DAG 以欄位合計平分為近似值;若來源日後改回
+    # 逐年列(如「112年度」),不會命中此 regex,會原樣通過。
+    combo = data["year"].astype("string").str.extract(r"^(\d+)-(\d+)年度$")
+    combo_mask = combo[0].notna()
+    split_rows = []
+    for idx in data.index[combo_mask]:
+        y1, y2 = int(combo.loc[idx, 0]), int(combo.loc[idx, 1])
+        if y2 != y1 + 1:
+            continue  # 非連續兩年拆不了,寧可整筆略過,也不寫入錯的數字
+        first, second = {"year": f"{y1}年度"}, {"year": f"{y2}年度"}
+        for col in [
+            "application_households",
+            "planned_households",
+            "approved_households",
+        ]:
+            total = pd.to_numeric(
+                str(data.loc[idx, col]).replace(",", ""), errors="coerce"
+            )
+            if pd.isna(total):
+                first[col] = second[col] = None
+            else:
+                first[col] = int(total) // 2
+                second[col] = int(total) - int(total) // 2
+        split_rows.append(first)
+        split_rows.append(second)
+    data = pd.concat([data[~combo_mask], pd.DataFrame(split_rows)], ignore_index=True)
     data["city"] = "臺北市"
     data["year"] = _to_ad_year(data["year"])
-    data = data[data["year"] <= 2022]
+    data = data[data["year"].notna()]
 
     # === Normalize ===
     for col in [

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/repair_subsidy_application_status/test_repair_subsidy_application_status.py
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/repair_subsidy_application_status/test_repair_subsidy_application_status.py
@@ -10,6 +10,7 @@ Run from DAG folder:
 from __future__ import annotations
 
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -28,7 +29,8 @@ TAIPEI_RID = "e54950a4-86b4-407b-bccf-180f17e1b310"
 
 def _fetch_data_taipei(rid: str) -> list[dict]:
     url = f"https://data.taipei/api/v1/dataset/{rid}?scope=resourceAquire&limit=2"
-    res = requests.get(url, timeout=30)
+    # data.taipei 憑證缺 Subject Key Identifier,新版 OpenSSL 驗證會失敗;DAG utils 同樣 verify=False
+    res = requests.get(url, timeout=30, verify=False)
     res.raise_for_status()
     body = res.json()
     records = (body.get("result") or {}).get("results") or []
@@ -53,9 +55,31 @@ def test_source_url_reachable():
     print(f"  data.taipei reachable, keys: {list(taipei_records[0].keys())[:12]}")
 
 
+def test_combined_year_row_values_numeric():
+    """合併年度列（如「112-113年度」）的補貼欄位須為數字，拆分邏輯才有依據。"""
+    url = f"https://data.taipei/api/v1/dataset/{TAIPEI_RID}?scope=resourceAquire&limit=1000"
+    res = requests.get(url, timeout=30, verify=False)
+    res.raise_for_status()
+    records = (res.json().get("result") or {}).get("results") or []
+    combined = [r for r in records if re.match(r"^\d+-\d+年度$", str(r.get("項目", "")))]
+    for row in combined:
+        for col in (
+            "修繕住宅貸款利息補貼申請戶數",
+            "修繕住宅貸款利息補貼計畫戶數",
+            "修繕住宅貸款利息補貼核定戶數",
+        ):
+            value = str(row.get(col, "")).replace(",", "").strip()
+            if not value.isdigit():
+                raise AssertionError(
+                    f"合併年度列 {row.get('項目')} 欄位非數字: {col}={row.get(col)}"
+                )
+    print(f"  combined-year rows: {len(combined)}, values numeric")
+
+
 if __name__ == "__main__":
     try:
         test_source_url_reachable()
+        test_combined_year_row_values_numeric()
     except Exception as e:
         print(f"FAIL [{TABLE_NAME}]: {e}", file=sys.stderr)
         sys.exit(1)


### PR DESCRIPTION
## 問題

同 #1358 的資料來源「臺北市歷年住宅補貼受理情形統計表」:最新一筆「項目」為 **112-113年度**(兩年合併)。`purchase_subsidy_application_status`、`repair_subsidy_application_status` 原以 `year <= 2022` 截斷,合併列進不了 ready table,對應的 `*_chart` 元件停在 111 年度。

## 做法

與 #1358 的 rental 相同的拆分策略,差異在**拆分依據**:備註僅載租金補貼數字,自購/修繕在合併列的三欄(申請/計畫/核定)都有實際合計值,故直接以**欄位合計平分**拆回 112、113 年度(餘數給後一年,兩年加總不變):

- 以 regex 比對 `^\d+-\d+年度$` 的合併年度列;非連續兩年或欄位非數值(如「見備註」)無從拆分時留空/略過,不寫入錯的數字。
- 移除 `year <= 2022` 截斷,改為過濾無效年度列。
- 若日後來源改回逐年列(如「112年度」),不會命中拆分 regex,原樣通過。
- job_config 不動(同 #1358:合併年度列可能為來源特例)。
- 測試:新增「合併年度列欄位須為數字」的來源契約檢查;fetch 補 `verify=False`(data.taipei 憑證缺 Subject Key Identifier)。

## 拆分結果(以來源實際資料驗證,總和皆不變)

| year | purchase 申請/計畫/核定 | repair 申請/計畫/核定 |
|---|---|---|
| 2023 (112年度) | 471 / 83 / 167 | 66 / 54 / 18 |
| 2024 (113年度) | 472 / 83 / 168 | 67 / 54 / 18 |
| 合計(=來源合併列) | 943 / 166 / 335 | 133 / 108 / 36 |

兩個 `test_*.py` 全數通過。**平分為近似值**:來源無逐年官方數字,採 sum-preserving 平分,與 #1358 口徑一致。

🤖 Generated with [Claude Code](https://claude.com/claude-code)