### PR TITLE
chore(housing_subsidy): 租金/自購/修繕補貼 DAG 改每月排程

### DIFF
--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/purchase_subsidy_application_status/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/purchase_subsidy_application_status/job_config.json
@@ -2,7 +2,7 @@
   "dag_infos": {
     "dag_id": "purchase_subsidy_application_status",
     "start_date": "2026-05-20",
-    "schedule_interval": "@yearly",
+    "schedule_interval": "@monthly",
     "catchup": false,
     "tags": ["housing", "都發局", "Taipei-City"],
     "description": "Yearly owner-occupied home purchase loan interest subsidy application status for Taipei.",
@@ -23,7 +23,7 @@
   },
   "data_infos": {
     "name_cn": "自購住宅貸款利息補貼受理情形",
-    "airflow_update_freq": "每年 (Asia/Taipei)",
+    "airflow_update_freq": "每月 (Asia/Taipei)",
     "source": "https://data.taipei/dataset/detail?id=6297943a-1e71-480d-967c-635855df66fe",
     "source_type": "data.taipei",
     "source_dept": "都發局",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/rental_subsidy_application_status/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/rental_subsidy_application_status/job_config.json
@@ -2,7 +2,7 @@
   "dag_infos": {
     "dag_id": "rental_subsidy_application_status",
     "start_date": "2026-05-20",
-    "schedule_interval": "@yearly",
+    "schedule_interval": "@monthly",
     "catchup": false,
     "tags": ["housing", "都發局", "Taipei-City"],
     "description": "Yearly rent subsidy application, planned, and approved households for Taipei.",
@@ -23,7 +23,7 @@
   },
   "data_infos": {
     "name_cn": "租金補貼受理情形",
-    "airflow_update_freq": "每年 (Asia/Taipei)",
+    "airflow_update_freq": "每月 (Asia/Taipei)",
     "source": "https://data.taipei/dataset/detail?id=6297943a-1e71-480d-967c-635855df66fe",
     "source_type": "data.taipei",
     "source_dept": "都發局",

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/repair_subsidy_application_status/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/repair_subsidy_application_status/job_config.json
@@ -2,7 +2,7 @@
   "dag_infos": {
     "dag_id": "repair_subsidy_application_status",
     "start_date": "2026-05-20",
-    "schedule_interval": "@yearly",
+    "schedule_interval": "@monthly",
     "catchup": false,
     "tags": ["housing", "都發局", "Taipei-City"],
     "description": "Yearly home repair loan interest subsidy application status for Taipei.",
@@ -23,7 +23,7 @@
   },
   "data_infos": {
     "name_cn": "修繕住宅貸款利息受理情形",
-    "airflow_update_freq": "每年 (Asia/Taipei)",
+    "airflow_update_freq": "每月 (Asia/Taipei)",
     "source": "https://data.taipei/dataset/detail?id=6297943a-1e71-480d-967c-635855df66fe",
     "source_type": "data.taipei",
     "source_dept": "都發局",


### PR DESCRIPTION
## 內容

三個住宅補貼 DAG(rental/purchase/repair)排程 `@yearly` → `@monthly`,`airflow_update_freq` 同步改「每月」。

## 原因

來源「臺北市歷年住宅補貼受理情形統計表」尚未把 112-113 合併列改回逐年(頁面與 CSV 均確認仍為合併列),更新時點不定。改每月輪詢後,來源更新(改回逐年或新增 114 年度)最慢一個月內自動跟上;#1358/#1364 的拆分邏輯只命中 `\d+-\d+年度` 格式,來源改回逐年時原樣通過,無需再改 code。

`load_behavior=replace`:每月重跑為整表重建,冪等、無累積副作用。

🤖 Generated with [Claude Code](https://claude.com/claude-code)