### PR TITLE
fix(generate_sql_to_create_DB_table): trigger 冪等 + 序列已 linked 時略過 owner 變更

### DIFF
--- a/Taipei-City-Dashboard-DE/dags/utils/generate_sql_to_create_DB_table.py
+++ b/Taipei-City-Dashboard-DE/dags/utils/generate_sql_to_create_DB_table.py
@@ -103,9 +103,10 @@ def generate_sql_to_create_db_table(
 
     create_mtime_trigger_sql = f"""
     
-    -- create mtime trigger
+    -- create mtime trigger（冪等：先 DROP 再 CREATE，避免表已存在時 trigger 重複建立而失敗）
+    DROP TRIGGER IF EXISTS {table_name}_mtime ON public.{table_name};
     CREATE TRIGGER {table_name}_mtime
-        BEFORE INSERT OR UPDATE 
+        BEFORE INSERT OR UPDATE
         ON public.{table_name}
         FOR EACH ROW
         EXECUTE PROCEDURE public.trigger_set_timestamp();
@@ -123,9 +124,16 @@ def generate_sql_to_create_db_table(
     """
 
     grant_sequnce_sql = f"""
-    
-    -- grant sequnce
-    ALTER TABLE IF EXISTS public.{table_name}_ogc_fid_seq OWNER to airflow;
+
+    -- grant sequnce（序列一旦 OWNED BY 資料表欄位，Postgres 就禁止單獨改它的 owner
+    -- (0A000 feature_not_supported)；此時 owner 會隨下方 ALTER TABLE ... OWNER 一併
+    -- 變更，故直接略過。其餘錯誤照常拋出。）
+    DO $$
+    BEGIN
+        ALTER TABLE IF EXISTS public.{table_name}_ogc_fid_seq OWNER to airflow;
+    EXCEPTION WHEN feature_not_supported THEN
+        NULL;
+    END $$;
     GRANT ALL ON TABLE public.{table_name}_ogc_fid_seq TO airflow WITH GRANT OPTION;
     """
 


### PR DESCRIPTION
## 背景

接續已合併的 #1378。該 PR 帶入的 39 個 DAG 全部都會呼叫 `generate_sql_to_create_db_table` 建 ready table,但 `develop-etl` 上這支共用 util 有**兩個會讓 DAG 在第二次執行時失敗**的問題,#1378 合併時這個修正還沒推上去,因此另開此 PR 補上。

SIT 上 `eco_friendly_restaurant_ntpe` 實際報錯:

```
psycopg2.errors.FeatureNotSupported: cannot change owner of sequence "eco_friendly_restaurant_ntpe_ogc_fid_seq"
DETAIL:  Sequence "eco_friendly_restaurant_ntpe_ogc_fid_seq" is linked to table "eco_friendly_restaurant_ntpe".
```

## 問題與修法

| # | 問題 | 症狀 | 修法 |
|---|---|---|---|
| 1 | `CREATE TRIGGER` 前沒有 `DROP TRIGGER IF EXISTS` | 表已存在時 → `DuplicateObject: trigger "..._mtime" already exists` | 先 `DROP IF EXISTS` 再 `CREATE` |
| 2 | 序列已 `OWNED BY` 資料表欄位時仍單獨下 `ALTER ... OWNER` | → `0A000 feature_not_supported`(上方線上錯誤) | 包進 `DO` 區塊,僅吞掉 `feature_not_supported` |

**成因(#2):** `load_behavior: replace` 以 GeoPandas 重建資料表時,會讓 `<table>_ogc_fid_seq` 連結(`OWNED BY`)到欄位。序列一旦 linked 且 owner 不是 `airflow`,Postgres 就禁止單獨改它的 owner。

序列 owner 本來就會隨後續的 `ALTER TABLE <table> OWNER to airflow` 連動變更,所以略過這個必然失敗的敘述沒有副作用;其餘錯誤照常拋出。

## 驗證

以拋棄式 Postgres 16 cluster 實測修正前後:

| 情境 | 修正前 | 修正後 |
|---|---|---|
| 全新建表 | ✅ | ✅ |
| 表已存在重跑 | ❌ `DuplicateObject` | ✅ |
| 序列 linked 且 owner 非 airflow | ❌ `FeatureNotSupported` | ✅ |

修正後最終狀態:table owner = `airflow`、sequence owner = `airflow`(隨 table 連動)、`_mtime` trigger 恰好 1 個。

> ⚠️ 此檔為共用 util,`develop-etl` 上約 200 個 DAG 都會用到。兩項變更都只是讓原本會失敗的 DDL 成功(trigger 改冪等、略過一個必然失敗且無意義的 ALTER),不影響目前正常運作的 DAG。

🤖 Generated with [Claude Code](https://claude.com/claude-code)