### PR TITLE
fix(load_stage): 空資料不得截斷目標表，TRUNCATE 與 INSERT 改為同一交易

### DIFF
--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/school_food_supply_chain_links/job_config.json
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/school_food_supply_chain_links/job_config.json
@@ -32,7 +32,7 @@
     "output_coordinate": "EPSG:4326",
     "is_geometry": 0,
     "dataset_description": "雙北中小學及高中職供餐食材供應鏈關係：上游原料／調味料供應商 → 中游供餐業者 → 下游學校。產出供桑基圖（SankeyChart）使用的 link rows。原始欄位含食材供應商與調味料供應商兩類上游關係",
-    "etl_description": "對每個縣市 scan-back 6 個月找最新可公開資料（資料延遲約 1-2 月）→ POST /opendatadownload/ 取一次性 timestamped 下載連結 → 立即 GET CSV → 食材供應商 + 調味料供應商 union 作為 up-mid source，groupby(supplier, 供餐業者) 計 row 數；mid-down groupby(供餐業者, 區域名稱, 學校名稱) 計 row 數 → replace 入庫。需 Airflow Variable: fatraceschool_accesscode",
+    "etl_description": "對每個縣市 scan-back 6 個月找最新可公開資料（資料延遲約 1-2 月）→ POST /opendatadownload/ 取一次性 timestamped 下載連結 → 立即 GET CSV → 食材供應商 + 調味料供應商 union 作為 up-mid source，groupby(supplier, 供餐業者) 計 row 數；mid-down groupby(供餐業者, 區域名稱, 學校名稱) 計 row 數 → replace 入庫。需 Airflow Variable: FATRACESCHOOL_ACCESSCODE",
     "sensitivity": "public"
   }
 }

--- a/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/school_food_supply_chain_links/school_food_supply_chain_links.py
+++ b/Taipei-City-Dashboard-DE/dags/proj_city_dashboard/school_food_supply_chain_links/school_food_supply_chain_links.py
@@ -58,6 +58,12 @@ def _school_food_supply_chain_links(**kwargs):
     from airflow.models import Variable
 
     ACCESS_CODE = Variable.get("FATRACESCHOOL_ACCESSCODE", default_var="")
+    if not ACCESS_CODE:
+        raise ValueError(
+            "Airflow Variable FATRACESCHOOL_ACCESSCODE 未設定。"
+            "空值時 API 仍回 HTTP 200 但 datasetList=null，會靜默寫入 0 筆；"
+            "因 load_behavior=replace，這會清空 ready 表。請先申請並設定 accesscode。"
+        )
 
     # === Helpers ===
     # NOTE: 暫無對應 utils.extract_stage helper 處理 fatraceschool API。
@@ -229,6 +235,8 @@ def _school_food_supply_chain_links(**kwargs):
     data = data[SELECT_COLUMNS]
 
     # === Load ===
+    # 抓不到資料時由 save_dataframe_to_postgresql 擋下並 raise，
+    # 不會以空資料清空 ready 表。
     engine = create_engine(ready_data_db_uri)
     _ensure_ready_table(engine, default_table, COL_MAP)
     save_dataframe_to_postgresql(

--- a/Taipei-City-Dashboard-DE/dags/proj_new_taipei_city_dashboard/school_food_supply_chain_links/school_food_supply_chain_links.py
+++ b/Taipei-City-Dashboard-DE/dags/proj_new_taipei_city_dashboard/school_food_supply_chain_links/school_food_supply_chain_links.py
@@ -58,6 +58,12 @@ def _school_food_supply_chain_links_ntpe(**kwargs):
     from airflow.models import Variable
 
     ACCESS_CODE = Variable.get("FATRACESCHOOL_ACCESSCODE", default_var="")
+    if not ACCESS_CODE:
+        raise ValueError(
+            "Airflow Variable FATRACESCHOOL_ACCESSCODE 未設定。"
+            "空值時 API 仍回 HTTP 200 但 datasetList=null，會靜默寫入 0 筆；"
+            "因 load_behavior=replace，這會清空 ready 表。請先申請並設定 accesscode。"
+        )
 
     # === Helpers ===
     BASE_URL = "https://fatraceschool.k12ea.gov.tw/cateringservice/openapi"
@@ -211,6 +217,8 @@ def _school_food_supply_chain_links_ntpe(**kwargs):
     data = data[SELECT_COLUMNS]
 
     # === Load ===
+    # 抓不到資料時由 save_dataframe_to_postgresql 擋下並 raise，
+    # 不會以空資料清空 ready 表。
     engine = create_engine(ready_data_db_uri)
     _ensure_ready_table(engine, default_table, COL_MAP)
     save_dataframe_to_postgresql(

--- a/Taipei-City-Dashboard-DE/dags/utils/load_stage.py
+++ b/Taipei-City-Dashboard-DE/dags/utils/load_stage.py
@@ -176,42 +176,45 @@ def save_dataframe_to_postgresql(
 
     start_time = time.time()
 
-    # main
-    conn = engine.connect()
-    if load_behavior == "append":
-        data.to_sql(
-            default_table, conn, if_exists="append", index=False, schema="public"
-        )
-    elif load_behavior == "replace":
-        conn.execute(
-            sa_text(f"TRUNCATE TABLE {default_table}").execution_options(
-                autocommit=True
-            )
-        )
-        data.to_sql(
-            default_table, conn, if_exists="append", index=False, schema="public"
-        )
-    elif load_behavior == "current+history":
-        if history_table is None:
-            raise ValueError(
-                "history_table should be provided when load_behavior is `current+history`."
-            )
-        conn.execute(
-            sa_text(f"TRUNCATE TABLE {default_table}").execution_options(
-                autocommit=True
-            )
-        )
-        data.to_sql(
-            default_table, conn, if_exists="append", index=False, schema="public"
-        )
-        data.to_sql(
-            history_table, conn, if_exists="append", index=False, schema="public"
-        )
-    else:
+    # 先確認有資料，才允許走會截斷目標表的寫入模式。
+    # 空資料 + TRUNCATE = 直接清空目標表，且清空後沒有任何資料補回來。
+    # (`append` 不截斷，寫 0 筆是無害的 no-op，不在此限。)
+    if data.empty and load_behavior in ("replace", "current+history"):
         raise ValueError(
-            "load_behavior should be one of `append`, `replace`, `current+history`."
+            f"Refuse to write empty data with load_behavior=`{load_behavior}`: "
+            f"it would truncate `{default_table}` and leave it empty."
         )
-    conn.close()
+
+    # main
+    # TRUNCATE 與 INSERT 必須在同一個 transaction 內：engine.begin() 讓寫入失敗時
+    # 連同 TRUNCATE 一起 rollback。否則 TRUNCATE 會立即 commit
+    # (SQLAlchemy 1.4 legacy autocommit)，寫入一失敗就留下被清空的表。
+    with engine.begin() as conn:
+        if load_behavior == "append":
+            data.to_sql(
+                default_table, conn, if_exists="append", index=False, schema="public"
+            )
+        elif load_behavior == "replace":
+            conn.execute(sa_text(f"TRUNCATE TABLE {default_table}"))
+            data.to_sql(
+                default_table, conn, if_exists="append", index=False, schema="public"
+            )
+        elif load_behavior == "current+history":
+            if history_table is None:
+                raise ValueError(
+                    "history_table should be provided when load_behavior is `current+history`."
+                )
+            conn.execute(sa_text(f"TRUNCATE TABLE {default_table}"))
+            data.to_sql(
+                default_table, conn, if_exists="append", index=False, schema="public"
+            )
+            data.to_sql(
+                history_table, conn, if_exists="append", index=False, schema="public"
+            )
+        else:
+            raise ValueError(
+                "load_behavior should be one of `append`, `replace`, `current+history`."
+            )
 
     # print
     cost_time = time.time() - start_time
@@ -302,62 +305,61 @@ def save_geodataframe_to_postgresql(
 
     start_time = time.time()
 
-    # main
-    conn = engine.connect()
-    if load_behavior == "append":
-        gdata.to_sql(
-            default_table,
-            conn,
-            if_exists="append",
-            index=False,
-            schema="public",
-            dtype={geometry_col: Geometry(geometry_type, srid=4326)},
-        )
-    elif load_behavior == "replace":
-        conn.execute(
-            sa_text(f"TRUNCATE TABLE {default_table}").execution_options(
-                autocommit=True
-            )
-        )
-        gdata.to_sql(
-            default_table,
-            conn,
-            if_exists="append",
-            index=False,
-            schema="public",
-            dtype={geometry_col: Geometry(geometry_type, srid=4326)},
-        )
-    elif load_behavior == "current+history":
-        if (history_table is None) or (history_table == ""):
-            raise ValueError(
-                "history_table should be provided when load_behavior is `current+history`."
-            )
-        conn.execute(
-            sa_text(f"TRUNCATE TABLE {default_table}").execution_options(
-                autocommit=True
-            )
-        )
-        gdata.to_sql(
-            default_table,
-            conn,
-            if_exists="append",
-            index=False,
-            schema="public",
-            dtype={geometry_col: Geometry(geometry_type, srid=4326)},
-        )
-        gdata.to_sql(
-            history_table,
-            conn,
-            if_exists="append",
-            index=False,
-            schema="public",
-            dtype={geometry_col: Geometry(geometry_type, srid=4326)},
-        )
-    else:
+    # 同 save_dataframe_to_postgresql：空資料不得走會截斷目標表的寫入模式。
+    if gdata.empty and load_behavior in ("replace", "current+history"):
         raise ValueError(
-            "load_behavior should be one of `append`, `replace`, `current+history`."
+            f"Refuse to write empty data with load_behavior=`{load_behavior}`: "
+            f"it would truncate `{default_table}` and leave it empty."
         )
-    conn.close()
+
+    # main
+    # TRUNCATE 與 INSERT 必須在同一個 transaction 內，理由同 save_dataframe_to_postgresql。
+    with engine.begin() as conn:
+        if load_behavior == "append":
+            gdata.to_sql(
+                default_table,
+                conn,
+                if_exists="append",
+                index=False,
+                schema="public",
+                dtype={geometry_col: Geometry(geometry_type, srid=4326)},
+            )
+        elif load_behavior == "replace":
+            conn.execute(sa_text(f"TRUNCATE TABLE {default_table}"))
+            gdata.to_sql(
+                default_table,
+                conn,
+                if_exists="append",
+                index=False,
+                schema="public",
+                dtype={geometry_col: Geometry(geometry_type, srid=4326)},
+            )
+        elif load_behavior == "current+history":
+            if (history_table is None) or (history_table == ""):
+                raise ValueError(
+                    "history_table should be provided when load_behavior is `current+history`."
+                )
+            conn.execute(sa_text(f"TRUNCATE TABLE {default_table}"))
+            gdata.to_sql(
+                default_table,
+                conn,
+                if_exists="append",
+                index=False,
+                schema="public",
+                dtype={geometry_col: Geometry(geometry_type, srid=4326)},
+            )
+            gdata.to_sql(
+                history_table,
+                conn,
+                if_exists="append",
+                index=False,
+                schema="public",
+                dtype={geometry_col: Geometry(geometry_type, srid=4326)},
+            )
+        else:
+            raise ValueError(
+                "load_behavior should be one of `append`, `replace`, `current+history`."
+            )
 
     # print
     cost_time = time.time() - start_time

--- a/Taipei-City-Dashboard-DE/dags/utils/load_stage.py
+++ b/Taipei-City-Dashboard-DE/dags/utils/load_stage.py
@@ -6,6 +6,20 @@ from sqlalchemy.sql import text as sa_text
 from utils.get_time import get_tpe_now_time_str
 
 
+def _truncate_if_exists(conn, table: str):
+    """表存在才 TRUNCATE。
+
+    表不存在是合法狀態(首次執行),後續 to_sql(if_exists='append') 會自動建表。
+    這裡用存在性檢查而非 try/except:在交易內讓 TRUNCATE 拋錯會使整個交易
+    進入 aborted 狀態,後續語句全部失敗,無法只吞掉這一個例外。
+    """
+    exists = conn.execute(
+        sa_text("SELECT to_regclass(:t)"), {"t": f"public.{table}"}
+    ).scalar()
+    if exists:
+        conn.execute(sa_text(f"TRUNCATE TABLE {table}"))
+
+
 def update_lasttime_in_data_to_dataset_info(
     engine, airflow_dag_id, lasttime_in_data=None
 ):
@@ -195,7 +209,7 @@ def save_dataframe_to_postgresql(
                 default_table, conn, if_exists="append", index=False, schema="public"
             )
         elif load_behavior == "replace":
-            conn.execute(sa_text(f"TRUNCATE TABLE {default_table}"))
+            _truncate_if_exists(conn, default_table)
             data.to_sql(
                 default_table, conn, if_exists="append", index=False, schema="public"
             )
@@ -204,7 +218,7 @@ def save_dataframe_to_postgresql(
                 raise ValueError(
                     "history_table should be provided when load_behavior is `current+history`."
                 )
-            conn.execute(sa_text(f"TRUNCATE TABLE {default_table}"))
+            _truncate_if_exists(conn, default_table)
             data.to_sql(
                 default_table, conn, if_exists="append", index=False, schema="public"
             )
@@ -325,7 +339,7 @@ def save_geodataframe_to_postgresql(
                 dtype={geometry_col: Geometry(geometry_type, srid=4326)},
             )
         elif load_behavior == "replace":
-            conn.execute(sa_text(f"TRUNCATE TABLE {default_table}"))
+            _truncate_if_exists(conn, default_table)
             gdata.to_sql(
                 default_table,
                 conn,
@@ -339,7 +353,7 @@ def save_geodataframe_to_postgresql(
                 raise ValueError(
                     "history_table should be provided when load_behavior is `current+history`."
                 )
-            conn.execute(sa_text(f"TRUNCATE TABLE {default_table}"))
+            _truncate_if_exists(conn, default_table)
             gdata.to_sql(
                 default_table,
                 conn,


### PR DESCRIPTION
## 問題

`save_dataframe_to_postgresql` / `save_geodataframe_to_postgresql` 在 `load_behavior=replace` / `current+history` 時「先 TRUNCATE 再寫入」，且 TRUNCATE 帶 `execution_options(autocommit=True)` 會**立即 commit**（SQLAlchemy 1.4 legacy autocommit）。兩條資料遺失路徑：

1. **空 DataFrame 寫入 = 直接清空目標表**，而且沒有任何資料補回來
2. **TRUNCATE 後寫入中斷 = 舊資料永久消失**，沒有 rollback

這不是理論問題。`school_food_supply_chain_links`（雙北兩支）因為 Airflow Variable `FATRACESCHOOL_ACCESSCODE` 從未設定過，`default_var=""` 讓 API 回 HTTP 200 + `datasetList: null`，scan-back 6 個月全部 miss → 寫入 0 筆 → **每月綠燈清空 ready 表**，自 2026-05 併入後從未抓到過資料，且 `dataset_info.lasttime_in_data` 被寫入字串 `"nan"`。

## 修正

- **空資料 + 截斷式模式（`replace` / `current+history`）直接 raise**，完全不動表。`append` 不截斷，寫 0 筆是無害 no-op，不受此限。
- `conn = engine.connect()` → `with engine.begin()`，**TRUNCATE 與 INSERT 進同一交易**，寫入失敗一併 rollback。
- 移除顯式交易內已無作用的 `execution_options(autocommit=True)`。

一併修正兩支 school_food DAG：accesscode 空值 fail-fast（不再送 6 次註定失敗的請求）、`job_config.json` 的 Variable 名稱大小寫對齊程式碼。

## 驗證

臨時 PostgreSQL 16 + **SQLAlchemy 1.4.54 + pandas 2.1.4**（= Airflow 2.10.5 constraints 實際鎖定的版本），直接 import 本模組測試：

| # | 情境 | 結果 |
|---|---|---|
| 1 | 空資料 + `replace` | raise 且表完好（3 筆）✅ |
| 2 | 空資料 + `current+history` | raise 且表完好（3 筆）✅ |
| 3 | 空資料 + `append` | 不 raise，表完好 ✅ |
| 4 | 正常資料 + `replace` | 換成新資料（2 筆）✅ |
| 5 | 正常資料 + `current+history` | t=2, t_h=2 ✅ |
| 6 | TRUNCATE 後寫入中斷 | rollback，舊資料保住（3 筆）✅ |

**6/6 passed。** 同一個 DB 跑修改前邏輯當對照組，情境 1 與 6 皆為 **3 筆 → 0 筆**。

## ⚠️ Reviewer 請注意

**影響範圍是 205 支 DAG**（93 支 `replace` + 112 支 `current+history` 共用此路徑）。行為變更為：0 筆從「靜默清表」改為「raise」。

**如果有哪支 DAG 本來就常態產出 0 筆**（例如某天沒事件的來源），它會從綠燈變紅燈。我沒有逐支檢查 205 支的資料特性 — 建議合併前掃一眼，或先在 SIT 觀察一輪。

**未實測**：`save_geodataframe_to_postgresql` 的改動與 dataframe 版結構完全相同，但執行驗證需要 PostGIS，未實際跑過。

## 不在此 PR 範圍

- `FATRACESCHOOL_ACCESSCODE` 仍未設定 → 這兩支 DAG 合併後會**紅燈**（原本是綠燈假成功）。存取碼需 email 註冊取得：`POST https://fatraceschool.k12ea.gov.tw/cateringservice/openapi/accountReg/` body `{"account":"<email>"}`。**建議用團隊共用信箱** — 原作者用個人信箱申請，離開專案後碼即失聯，正是本次成因。
- `dataset_info.lasttime_in_data` 已寫入的字串 `"nan"` 需另行清理（DB 側，程式改不掉）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
